### PR TITLE
Remove Table Sync Supressions

### DIFF
--- a/app/sync_tabular_data_with_carto.rb
+++ b/app/sync_tabular_data_with_carto.rb
@@ -72,22 +72,7 @@ end
 
 tables_to_sync = ActiveRecord::Base.connection.tables - carto_tables
 no_permission_to_sync = ActiveRecord::Base.connection.tables - tables_with_permission
-tables_to_skip = ["b17026_income_to_poverty_by_families_acs_ct",
-                  "b18101_disability_by_gender_age_acs_ct",
-                  "b19001_hh_income_acs_ct",
-                  "b08134_means_by_traveltime_to_work_acs_bg",
-                  "b18135_health_insurance_by_disability_status_acs_ct",
-                  "b19037_hh_income_by_age_race_acs_ct",
-                  "b07403_geomobility_out_migration_acs_m",
-                  "b08303_traveltime_to_work_by_residence_acs_m",
-                  "b08006_means_transportation_to_work_by_residence_gender_acs_ct",
-                  "b25046_b25044_b01003_hh_vehicle_ownership_acs_m",
-                  "b25002_b25003_hu_occupancy_by_tenure_race_acs_bg",
-                  "b23025_employment_acs_ct",
-                  "b11007_hh_with_seniors_acs_ct",
-                  "b22002_hh_foodstamps_snap_hhtype_kids_acs_m",
-                  "demo_race_latino_detail_ct",
-                  "b17001_poverty_by_age_gender_acs_m",
+tables_to_skip = ["b08134_means_by_traveltime_to_work_acs_bg",
                   "_data_browser"]
 tables_with_permission_to_sync = tables_to_sync - no_permission_to_sync - tables_to_skip
 count = tables_with_permission_to_sync.count


### PR DESCRIPTION
This commit removes the now working table supressions that were tested as part of #54. We still supress data_browser because that is a meta table and the means_by_traveltime_to_work_acs_bg because we do not know why that table is failing to sync. However all the other tables sync’d correctly with a manual POST sync request.