### PR TITLE
Update Metadata Style

### DIFF
--- a/public/assets/styles/routes/datasets.scss
+++ b/public/assets/styles/routes/datasets.scss
@@ -39,6 +39,7 @@
     }
 
     em { font-weight: 700; }
+    &:not(:first-of-type) { margin-left: 30px; } to &:not(:last-of-type) { margin-right: 30px; }
   }
 
   .year-filter {

--- a/public/assets/styles/routes/datasets.scss
+++ b/public/assets/styles/routes/datasets.scss
@@ -34,12 +34,10 @@
 
     li {
       display: inline-block;
-
-      &:not(:first-of-type) { margin-left: 30px; }
+      &:not(:last-of-type) { margin-right: 30px; }
     }
 
     em { font-weight: 700; }
-    &:not(:first-of-type) { margin-left: 30px; } to &:not(:last-of-type) { margin-right: 30px; }
   }
 
   .year-filter {


### PR DESCRIPTION
This commit cleans up the metadata style for the data browser.

# Why is this change necessary?

It was suggested by @ericyoungberg in https://github.com/MAPC/databrowser/pull/8#issuecomment-410729303 in order to improve the display of metadata.

# How does it address the issue?

It makes it so that the metadata is better formatted.