### PR TITLE
Update Shapefile Endpoint for PRQL

### DIFF
--- a/app/shapefile.rb
+++ b/app/shapefile.rb
@@ -55,7 +55,7 @@ module Shapefile
       arguments = []
       arguments << %Q(-f 'ESRI Shapefile' public/#{file_name}.shp)
       arguments << %Q(PG:'host=#{@settings['database']['host']} port=#{@settings['database']['port']} user=#{@settings['database']['username']} dbname=#{@settings['database']['geospatial']['database']} password=#{@settings['database']['password']}')
-      arguments << %Q(-sql 'SELECT *,sde.ST_AsText(shape) FROM #{@settings['database']['geospatial']['schema']['data']}.#{table_name}' -skipfailures)
+      arguments << %Q(-sql 'SELECT *,sde.ST_AsText(shape) FROM #{table_name}' -skipfailures)
 
       `ogr2ogr #{arguments.join(" ")}`
 


### PR DESCRIPTION
In our refactoring of DataBrowser for PRQL we added the table schema to requests data browser sends. Unfortunately the shapefile endpoint was not updated to reflect this. This commit updates the command to properly point to the right table and schema based on the request from databrowser.
