### PR TITLE
Deploy React App to Staging

### DIFF
--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -34,6 +34,8 @@ set :passenger_restart_command, 'passenger-config restart-app'
 set :rvm_custom_path, '/usr/share/rvm'
 set :branch, 'dev'
 
+after 'deploy:published', 'compile_react:staging'
+
 
 
 # Custom SSH Options

--- a/lib/capistrano/tasks/compile_react.rake
+++ b/lib/capistrano/tasks/compile_react.rake
@@ -1,0 +1,8 @@
+namespace :compile_react do
+  desc 'Compile React application with Parcel and deploy to staging'
+  task :staging do
+    run_locally do
+      system 'cd public; yarn run staging'
+    end
+  end
+end


### PR DESCRIPTION
This adds a post deploy hook to Capistrano to automatically deploy the react application to the staging server so that running future staging deployments does not blow away the React application.