### PR TITLE
Fix dataset count

### DIFF
--- a/public/app/actions/dataset.js
+++ b/public/app/actions/dataset.js
@@ -6,7 +6,7 @@ import locations from '~/app/constants/locations';
 export function fetchAll() {
   return async (dispatch, getState) => {
     if (getState().dataset.cache.length === 0 ) {
-      const response = await fetch(`${locations.BROWSER_API}SELECT * FROM tabular._data_browser WHERE schemaname='tabular' OR schemaname='mapc' AND active='Y'`)
+      const response = await fetch(`${locations.BROWSER_API}?token=${locations.DS_TOKEN}&query=SELECT * FROM tabular._data_browser WHERE schemaname='tabular' OR schemaname='mapc' AND active='Y'`)
       const payload = await response.json();
 
       return dispatch(update(payload.rows));


### PR DESCRIPTION
**Why is this change necessary?**
I broke the dataset count when I generalized the locations.BROWSER_API to require a specific token to be specified.