### PR TITLE
Add TownData Endpoint

### DIFF
--- a/app/town_metadata.rb
+++ b/app/town_metadata.rb
@@ -1,0 +1,83 @@
+#!/usr/bin/env ruby
+require 'active_record'
+require 'active_support/core_ext/hash'
+require 'yaml'
+require 'nokogiri'
+require 'rack'
+require 'erb'
+
+module TownMetadata
+  class API
+    def connect_to_town_database
+      template = ERB.new File.new("config/settings.yml").read
+      @settings = YAML.load template.result(binding)
+
+      ActiveRecord::Base.establish_connection(
+        adapter:  'postgresql',
+        host: @settings['database']['host'],
+        port: @settings['database']['port'],
+        database: @settings['database']['town']['database'],
+        username: @settings['database']['username'],
+        password: @settings['database']['password'],
+        schema_search_path: @settings['database']['town']['schema']['metadata']
+      )
+    end
+
+    def metadata_for(tables, columns)
+      if tables
+        conditions = tables.map{|table| "LOWER(name) LIKE LOWER('#{table}')"}.join(' OR ')
+        where_clause = "WHERE #{conditions}"
+      else
+        where_clause = ''
+      end
+
+      sql = <<~SQL
+      SELECT
+        #{columns}
+      FROM
+        gdb_items
+      #{where_clause};
+      SQL
+      ActiveRecord::Base.connection.execute(sql)
+    end
+
+    def response(request)
+        connect_to_town_database
+        prefix = 'towndata.mapc.'
+        metadata = {}
+
+        if request.params['tables']
+          tables = request.params['tables'].split(',')
+          tables.map!{|x| "#{prefix}#{x}"}
+        else
+          tables = nil
+        end
+
+        if request.params['columns']
+          columns = request.params['columns'].split(',')
+
+          unless columns.include?('name')
+            columns << 'name'
+          end
+
+          columns = columns.join(',')
+        else
+          columns = 'name,definition,documentation'
+        end
+
+        metadata_for(tables, columns).each do |table|
+          table_name = table['name'].sub(prefix, '').downcase
+
+          metadata[table_name] = {}
+          metadata[table_name]['documentation'] = Hash.from_xml(table['documentation']) unless table['documentation'].blank?
+          metadata[table_name]['definition'] = Hash.from_xml(table['definition']) unless table['definition'].blank?
+        end
+
+        [200, {'Content-Type' => 'application/json'}, [metadata.to_json]]
+    end
+
+    def call(env)
+      response(Rack::Request.new(env))
+    end
+  end
+end

--- a/config.ru
+++ b/config.ru
@@ -4,6 +4,7 @@ require 'rack/cors'
 require_relative 'app/geospatial_metadata'
 require_relative 'app/tabular_metadata'
 require_relative 'app/shapefile'
+require_relative 'app/town_metadata'
 
 use Rack::Cors do
   known_origins = [
@@ -18,12 +19,16 @@ use Rack::Cors do
   end
 end
 
-map '/geospatial' do
+map '/gisdata' do
   run GeospatialMetadata::API.new
 end
 
-map '/tabular' do
+map '/ds' do
   run TabularMetadata::API.new
+end
+
+map '/towndata' do
+  run TownMetadata::API.new
 end
 
 map '/shapefile' do

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -13,6 +13,11 @@ database:
     schema:
       data: <%= ENV['DATABASE_TABULAR_SCHEMA_DATA'] %>
       metadata: <%= ENV['DATABASE_TABULAR_SCHEMA_METADATA'] %>
+  town:
+    database: <%= ENV['DATABASE_TOWN_DATABASE'] %>
+    schema:
+      data: <%= ENV['DATABASE_TOWN_SCHEMA_DATA'] %>
+      metadata: <%= ENV['DATABASE_TOWN_SCHEMA_METADATA'] %>
 carto:
   api_key: <%= ENV['CARTO_API_KEY'] %>
   url: <%= ENV['CARTO_URL'] %>


### PR DESCRIPTION
This commit adds an endpoint to allow for the summoning of metadata in the towndata database.

* Refactor endpoint names to correspond to database names instead of schemas
* This will break databrowser until it is updated to reflect the new convention
* Because the names of the tables in the metadata table start with a capital letter we must downcase it in the code to achieve a match.
* End users will need to set database information in settings.yml
