### PR TITLE
Resolve #134 Fix dataset count

### DIFF
--- a/datacommon.sublime-project
+++ b/datacommon.sublime-project
@@ -2,7 +2,8 @@
 	"folders":
 	[
 		{
-			"path": "."
+			"path": ".",
+      "folder_exclude_patterns": [".cache", "dist", "node_modules"],
 		}
 	]
 }

--- a/public/app/actions/dataset.js
+++ b/public/app/actions/dataset.js
@@ -6,7 +6,7 @@ import locations from '~/app/constants/locations';
 export function fetchAll() {
   return async (dispatch, getState) => {
     if (getState().dataset.cache.length === 0 ) {
-      const response = await fetch(`${locations.BROWSER_API}?token=${locations.DS_TOKEN}&query=SELECT * FROM tabular._data_browser WHERE schemaname='tabular' OR schemaname='mapc' AND active='Y'`)
+      const response = await fetch(`${locations.BROWSER_API}?token=${locations.DS_TOKEN}&query=SELECT * FROM tabular._data_browser WHERE active='Y'`)
       const payload = await response.json();
 
       return dispatch(update(payload.rows));


### PR DESCRIPTION
This commit fixes the dataset count on the front page to match what is seen in the Databrowser portion of the app.

It also adds some node related folders to the sublime project file so they are helpfully ignored when searching.

Resolves #134.
