### PR TITLE
Resolve #170 Add CSV Endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-ruby "2.5.0"
+ruby "2.5.1"
 source 'https://rubygems.org'
 gem 'pry-byebug'
 gem 'faraday'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,7 +103,7 @@ DEPENDENCIES
   rubyzip
 
 RUBY VERSION
-   ruby 2.5.0p0
+   ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.2
+   1.16.4

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 sudo add-apt-repository ppa:ubuntugis/ppa && sudo apt-get update
 sudo apt-get install gdal-bin
 ```
+8. The user you run the application under needs a valid `.pgpass` file in their home directory with credentials to access the defined databases in order for the csv endpoint to work.
 
 ## Testing
 All server-side tests are written in RSpec.

--- a/app/csv.rb
+++ b/app/csv.rb
@@ -21,6 +21,10 @@ module Csv
   end
 
   class API
+    def allowed_database_name(database_name)
+      ['ds', 'gisdata', 'towndata'].include?(database_name) ? database_name : nil
+    end
+
     def to_csv(table_name, database_name)
       template = ERB.new File.new("config/settings.yml").read
       @settings = YAML.load template.result(binding)
@@ -28,7 +32,7 @@ module Csv
       file_name = "export-#{table_name}-#{Time.now.to_i}.csv"
       arguments = []
       arguments << %Q(-c "\\copy (SELECT * FROM #{table_name}) to 'public/#{file_name}' with csv")
-      arguments << %Q(-w -h #{@settings['database']['host']} -p #{@settings['database']['port']} -U #{@settings['database']['username']} -d #{database_name})
+      arguments << %Q(-w -h #{@settings['database']['host']} -p #{@settings['database']['port']} -U #{@settings['database']['username']} -d #{allowed_database_name(database_name)})
       arguments << %Q(> log/psql.log 2>&1)
 
       `psql #{arguments.join(" ")}`

--- a/app/csv.rb
+++ b/app/csv.rb
@@ -1,0 +1,50 @@
+#!/usr/bin/env ruby
+require 'active_record'
+require 'active_support/core_ext/hash'
+require 'yaml'
+require 'nokogiri'
+require 'rack'
+require 'erb'
+require 'pry-byebug'
+
+module Csv
+  class FileStreamer
+    def initialize(path)
+      @file = File.open(path)
+    end
+
+    def each(&blk)
+      @file.each(&blk)
+    ensure
+      @file.close
+    end
+  end
+
+  class API
+    def to_csv(table_name)
+      template = ERB.new File.new("config/settings.yml").read
+      @settings = YAML.load template.result(binding)
+
+      file_name = "export-#{table_name}-#{Time.now.to_i}.csv"
+      arguments = []
+      arguments << %Q(-c "\\copy (SELECT * FROM #{table_name}) to 'public/#{file_name}' with csv")
+      arguments << %Q(-w -h #{@settings['database']['host']} -p #{@settings['database']['port']} -U #{@settings['database']['username']} -d #{@settings['database']['tabular']['database']})
+      arguments << %Q(> log/psql.log 2>&1)
+
+      `psql #{arguments.join(" ")}`
+
+      puts arguments.join(" ")
+
+      return file_name
+    end
+
+    def response(request)
+      file = to_csv(request.params['table'])
+      [200, {'Content-Type' => 'text/csv', 'Content-Disposition' => 'attachment'}, FileStreamer.new("public/#{file}")]
+    end
+
+    def call(env)
+      response(Rack::Request.new(env))
+    end
+  end
+end

--- a/config.ru
+++ b/config.ru
@@ -5,6 +5,7 @@ require_relative 'app/geospatial_metadata'
 require_relative 'app/tabular_metadata'
 require_relative 'app/shapefile'
 require_relative 'app/town_metadata'
+require_relative 'app/csv'
 
 use Rack::Cors do
   known_origins = [
@@ -33,4 +34,8 @@ end
 
 map '/shapefile' do
   run Shapefile::API.new
+end
+
+map '/csv' do
+  run Csv::API.new
 end


### PR DESCRIPTION
Resolves #170.

# Why is this change necessary?
Users would like to download CSV files and the move to PRQL has removed this feature.

# How does it address the issue?
It adds an endpoint to data common to allow for CSV downloads of datasets

# What side effects does it have?
None.
