### PR TITLE
Lock map and add babel-polyfill

### DIFF
--- a/public/.babelrc
+++ b/public/.babelrc
@@ -5,7 +5,7 @@
     "wildcard",
     [
       "transform-runtime", {
-        "polyfill": false,
+        "polyfill": true,
         "regenerator": true
       }
     ]

--- a/public/app/components/MapBox.jsx
+++ b/public/app/components/MapBox.jsx
@@ -40,13 +40,19 @@ class MapBox extends React.Component {
     this.map = new mapboxgl.Map({
       container: this.mapContainer,
       style: 'mapbox://styles/ihill/cjjyl8uj509sj2smehs79fzyq',
-      center: [-72, 42.36],
-      maxBounds: [[-75.6, 41], [-69.5, 43.1]],
-      zoom: 7,
-      minZoom: 7,
-      maxZoom: 11,
+      scrollZoom: false,
+      dragPan: false,
+      dragRotate: false,
+      doubleClickZoom: false,
+      boxZoom: false,
+      interactive: false,
       ...this.props,
     });
+
+    this.map.fitBounds([[-73.5081481933594, 41.1863288879395], [-69.8615341186523, 42.8867149353027]], {
+      padding: { top: 30, left: 300, right: 30, bottom: 30 },
+      animate: false,
+    })
 
     this.map.on('load', () => {
       this.map.resize();

--- a/public/app/components/visualizations/StackedBarChart.jsx
+++ b/public/app/components/visualizations/StackedBarChart.jsx
@@ -131,16 +131,28 @@ class StackedBarChart extends React.Component {
       .attr('class', 'layer')
       .attr('fill', d => this.color(d.key));
 
+    console.log(catScale.bandwidth(), catScale.range(), catScale.domain())
+
+    // For charts with less than 3 bars, limit the width to one third of the
+    // chart's width
+    const [ catMin, catMax ] = catScale.range();
+    const columnWidth = catScale.domain().length < 3
+        ? (((catMax - catMin) / 3) + catMin)
+        : catScale.bandwidth();
+    const realignment = catScale.domain().length < 3
+        ? (catScale.bandwidth() - ((catMax - catMin) / 3)) / 2
+        : 0;
+
     layer.selectAll("rect")
   	  .data(d => d)
       .enter()
       .append("rect")
-      .attr((this.props.horizontal ? 'y' : 'x'), d => catScale(d.data.y))
+      .attr((this.props.horizontal ? 'y' : 'x'), d => catScale(d.data.y) + realignment)
       .attr((this.props.horizontal ? 'x' : 'y'), d => (this.props.horizontal ? valScale(d[0]) : valScale(d[1])))
       .attr((this.props.horizontal ? 'width' : 'height'), d => (this.props.horizontal
           ? (valScale(d[1]) - valScale(d[0]))
           : (valScale(d[0]) - valScale(d[1]))))
-      .attr((this.props.horizontal ? 'height' : 'width'), catScale.bandwidth());
+      .attr((this.props.horizontal ? 'height' : 'width'), columnWidth);
 
     const xAxisG = this.gChart.append('g')
       .attr('class', 'axis axis-x')

--- a/public/app/constants/charts.js
+++ b/public/app/constants/charts.js
@@ -170,7 +170,7 @@ export default {
         emp: 'Employed',
         unemp: 'Unemployed',
       },
-      source: 'Executive Office of Labor and Workforce Development (EOLWD)',
+      source: 'ACS',
       timeframe: '2007-2011 and 2012-2016 5-Year Estimates',
       datasetLinks: { 'Labor Force (Municipal)': 129 },
       transformer: (tables, chart) => {

--- a/public/app/index.jsx
+++ b/public/app/index.jsx
@@ -1,3 +1,5 @@
+require('es6-promise').polyfill();
+require('isomorphic-fetch');
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';

--- a/public/package.json
+++ b/public/package.json
@@ -14,8 +14,11 @@
     "test:coverage": "yarn test --coverage"
   },
   "dependencies": {
+    "babel-polyfill": "^6.26.0",
     "d3": "npm:d3",
+    "es6-promise": "^4.2.4",
     "history": "^4.7.2",
+    "isomorphic-fetch": "^2.2.1",
     "path-to-regexp": "^2.2.1",
     "prop-types": "^15.6.1",
     "react": "^0.14.0 || ^15.0.0-0 || ^16.0.0-0",

--- a/public/yarn.lock
+++ b/public/yarn.lock
@@ -1646,6 +1646,10 @@ es-to-primitive@^1.1.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.1"
 
+es6-promise@^4.2.4:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.4.tgz#dc4221c2b16518760bd8c39a52d8f356fc00ed29"
+
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
@@ -2490,7 +2494,7 @@ isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
 
-isomorphic-fetch@^2.1.1:
+isomorphic-fetch@^2.1.1, isomorphic-fetch@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
   dependencies:


### PR DESCRIPTION
Resolves #169. Resolves #175.

**Why is this change necessary?**
Lock map and add babel-polyfill for IE.