### PR TITLE
Add production deployment scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ sudo add-apt-repository ppa:ubuntugis/ppa && sudo apt-get update
 sudo apt-get install gdal-bin
 ```
 8. The user you run the application under needs a valid `.pgpass` file in their home directory with credentials to access the defined databases in order for the csv endpoint to work.
+9. We have enabled caching in 20 minute periods on prql.mapc.org in its nginx configuration. This may cause issues later and should be investigated if data does not refresh as expected.
 
 ## Testing
 All server-side tests are written in RSpec.

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -34,6 +34,7 @@ set :passenger_restart_command, 'passenger-config restart-app'
 set :rvm_custom_path, '/usr/share/rvm'
 set :branch, 'master'
 
+after 'deploy:published', 'compile_react:production'
 
 # Custom SSH Options
 # ==================

--- a/lib/capistrano/tasks/compile_react.rake
+++ b/lib/capistrano/tasks/compile_react.rake
@@ -5,4 +5,11 @@ namespace :compile_react do
       system 'cd public; yarn run staging'
     end
   end
+
+  desc 'Compile React application with Parcel and deploy to production'
+  task :production do
+    run_locally do
+      system 'cd public; yarn run production'
+    end
+  end
 end

--- a/public/package.json
+++ b/public/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "start": "parcel index.html",
     "staging": "NODE_ENV=staging parcel build index.html && rsync -r dist/* datacommon@prep.mapc.org:/var/www/datacommon/current/public/",
+    "production": "NODE_ENV=production parcel build index.html && rsync -r dist/* datacommon@live.mapc.org:/var/www/datacommon/current/public/",
     "test": "jest",
     "test:watch": "yarn test --watch",
     "test:coverage": "yarn test --coverage"


### PR DESCRIPTION
Add and update scripts to deploy to production.

# Why is this change necessary?
So we can deploy to production.

# How does it address the issue?
Adding a note in the README.md about our caching of PRQL to warn future generations of the caching issues they may face, and then adding scripts to push to production.

# What side effects does it have?
🚀
