### PR TITLE
Hide horizontal scroll bar in databrowser before it's needed

### DIFF
--- a/public/assets/styles/modules/header.scss
+++ b/public/assets/styles/modules/header.scss
@@ -10,7 +10,7 @@ header {
 
   nav {
     flex: 1 0;
-    overflow-x: scroll;
+    overflow-x: auto;
     .scroll-wrapper {
       width: max-content;
       div, ul {


### PR DESCRIPTION
**Why is this change necessary?**
The header in databrowser looks like this:
![screen shot 2018-10-03 at 10 13 51 am](https://user-images.githubusercontent.com/6565554/46416238-1831bc80-c6f5-11e8-917b-f50a4f6d697d.png)

**How does it address the issue?**
Semantic UI forces the horizontal scroll bar to show before it's needed, so setting overflow-x to auto hides it before we reach mobile dimensions.