### PR TITLE
Implement flex columns on category lists in Browser

### DIFF
--- a/public/assets/styles/routes/categories.scss
+++ b/public/assets/styles/routes/categories.scss
@@ -32,6 +32,16 @@
         border: 1px solid $color_font-medium;
       }
     }
+
+    .category-item-content {
+      display: flex;
+
+      & > .category-item-column {
+        flex: 1 1 75%;
+
+        &:last-of-type { flex: 0 1 25%; }
+      }
+    }
   }
 
 }


### PR DESCRIPTION
Resolves #190 . Implemented by https://github.com/MAPC/databrowser/pull/25

# Why is this change necessary?
Long category titles in the category list panels of Browser would cause the dataset count within those categories to be displaced downwards. 

# How does it address the issue?
Implements a flex structure that allows the category title and dataset count to share the space

# What side effects does it have?
None
