### PR TITLE
Implement flex columns for table header meta info

### DIFF
--- a/public/assets/styles/routes/datasets.scss
+++ b/public/assets/styles/routes/datasets.scss
@@ -94,9 +94,24 @@
     }
   }
 
+  .dataset-details-content {
+    display: flex;
+
+    & > .details-content-column {
+      flex: 1 0 75%;
+
+      &:last-of-type {
+        flex: 1 0 23%;
+        top: -30px;
+
+        margin-left: 2%;
+
+        text-align: right;
+      }
+    }
+  }
+
   .download-links {
-    position: absolute;
-    bottom: 11px;
     right: 0;
 
     font-size: $font_size-xsmall;


### PR DESCRIPTION
Resolves #167 .

# Why is this change necessary?
The meta info in the header of Browser's tables would overlap with the download buttons if the information associated with the table is of sufficient length. 

# How does it address the issue?
Implements flex columns to allow the information to share the space with the download buttons.

# What side effects does it have?
None