### PR TITLE
Download selected years

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 log/
 .env
 **/node_modules
+public/cache/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN set -ex \
     apk update \
     && apk add --no-cache \
       build-base \
+      postgresql \
       postgresql-dev \
     ; \
     bundle install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM ruby:2.5.3-alpine
+MAINTAINER Eric Youngberg <eyoungberg@mapc.org>
+
+WORKDIR /usr/src/app
+VOLUME /usr/src/app
+EXPOSE 9292
+
+COPY Gemfile* ./
+
+RUN set -ex \
+    ; \
+    apk update \
+    && apk add --no-cache \
+      build-base \
+      postgresql-dev \
+    ; \
+    bundle install
+
+CMD rm -f tmp/pids/server.pid && rackup -o 0.0.0.0

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ begin
   desc 'Launch app Docker container'
   task :start do
     system("docker build -t datacommon/app .") 
-    system("docker run -it --rm -v $(PWD):/usr/src/app -p '9292:9292' --name datacommon_app datacommon/app") 
+    system("docker run -it --rm --env-file $(PWD)/.env -v $(PWD):/usr/src/app -p '9292:9292' --name datacommon_app datacommon/app") 
   end
 
   desc 'Remove Docker images'

--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,17 @@ begin
   require 'rspec/core/rake_task'
   RSpec::Core::RakeTask.new(:spec)
   task :default => :spec
+
+  desc 'Launch app Docker container'
+  task :start do
+    system("docker build -t datacommon/app .") 
+    system("docker run -it --rm -v $(PWD):/usr/src/app -p '9292:9292' --name datacommon_app datacommon/app") 
+  end
+
+  desc 'Remove Docker images'
+  task :clean do
+    system("docker rmi -f datacommon/app")
+  end
 rescue LoadError
   # no rspec available
 end

--- a/app/csv.rb
+++ b/app/csv.rb
@@ -5,6 +5,7 @@ require 'yaml'
 require 'nokogiri'
 require 'rack'
 require 'erb'
+require 'fileutils'
 
 module Csv
   class FileStreamer
@@ -20,21 +21,40 @@ module Csv
   end
 
   class API
+    @@cache_dir = 'public/cache'
+
     def allowed_database_name(database_name)
       ['ds', 'gisdata', 'towndata'].include?(database_name) ? database_name : nil
     end
 
-    def to_csv(table_name, database_name)
+    def generate_filename(table_name, years = nil)
+      if years
+        years = years.split(',').sort
+        years = ':' + years.join('_')
+      end
+
+      "#{table_name}#{years}.csv"
+    end
+
+    def to_csv(table_name, database_name, years = nil, year_col = nil)
       template = ERB.new File.new("config/settings.yml").read
       @settings = YAML.load template.result(binding)
 
-      file_name = "#{table_name}.csv"
+      file_name = generate_filename(table_name, years)
       arguments = []
-      arguments << %Q(-c "\\copy (SELECT * FROM #{table_name}) to 'public/#{file_name}' with csv header")
-      arguments << %Q(-w -h #{@settings['database']['host']} -p #{@settings['database']['port']} -U #{@settings['database']['username']} -d #{allowed_database_name(database_name)})
-      arguments << %Q(> log/psql.log 2>&1)
+      arguments << %Q(-c "\\copy \(SELECT * FROM #{table_name})
 
-      `psql #{arguments.join(" ")}`
+      if years
+        year_options = years.split(',').map{|year| "'#{year}'"}.join(',')
+        arguments << %Q(WHERE #{year_col} IN (#{year_options}) ORDER BY #{year_col} DESC)
+      end
+
+      arguments << %Q(\) to '#{File.join(@@cache_dir, file_name)}' with csv header")
+      arguments << %Q(-w -h #{@settings['database']['host']} -p #{@settings['database']['port']} -U #{@settings['database']['username']} -d #{allowed_database_name(database_name)})
+
+      psql_out = `psql #{arguments.join(' ')} 2>&1`
+      FileUtils.mkdir_p('log')
+      File.open('log/psql.log', 'a') { |file| file.write(psql_out) }
 
       puts arguments.join(" ")
 
@@ -42,12 +62,14 @@ module Csv
     end
 
     def response(request)
-      if File.file?(Rack::Directory.new('public').root + "/#{request.params['table']}.csv")
-        file = "#{request.params['table']}.csv"
-      else
-        file = to_csv(request.params['table'], request.params['database'])
+      filename = generate_filename(request.params['table'], request.params['years'])
+
+      FileUtils.mkdir_p(@@cache_dir)
+      unless File.file?(File.join(@@cache_dir, filename))
+        to_csv(request.params['table'], request.params['database'], request.params['years'], request.params['year_col'])
       end
-      [200, {'Content-Type' => 'text/csv', 'Content-Disposition' => "attachment;filename=\"#{request.params['table']}.csv\""}, FileStreamer.new("public/#{file}")]
+
+      [200, {'Content-Type' => 'text/csv', 'Content-Disposition' => "attachment;filename=\"#{filename}\""}, FileStreamer.new(File.join(@@cache_dir, filename))]
     end
 
     def call(env)

--- a/app/shapefile.rb
+++ b/app/shapefile.rb
@@ -6,6 +6,7 @@ require 'nokogiri'
 require 'rack'
 require 'erb'
 require 'zip'
+require 'fileutils'
 
 module Shapefile
   class FileStreamer
@@ -21,16 +22,20 @@ module Shapefile
   end
 
   class API
+    @@cache_dir = 'public/cache'
+
     def allowed_database_name(database_name)
       ['ds', 'gisdata', 'towndata'].include?(database_name) ? database_name : nil
     end
 
     def zip(file_name)
-      Zip::File.open("public/#{file_name}.zip", Zip::File::CREATE) do |zipfile|
+      file_path = File.join(@@cache_dir, file_name)
+
+      Zip::File.open("#{file_path}.zip", Zip::File::CREATE) do |zipfile|
         zipfile.add("#{file_name}.prj", "public/26986.prj")
-        zipfile.add("#{file_name}.shp", "public/#{file_name}.shp")
-        zipfile.add("#{file_name}.shx", "public/#{file_name}.shx")
-        zipfile.add("#{file_name}.dbf", "public/#{file_name}.dbf")
+        zipfile.add("#{file_name}.shp", "#{file_path}.shp")
+        zipfile.add("#{file_name}.shx", "#{file_path}.shx")
+        zipfile.add("#{file_name}.dbf", "#{file_path}.dbf")
       end
       return "#{file_name}.zip"
     end
@@ -41,7 +46,7 @@ module Shapefile
 
       file_name = "export-#{table_name}"
       arguments = []
-      arguments << %Q(-f 'ESRI Shapefile' public/#{file_name}.shp)
+      arguments << %Q(-f 'ESRI Shapefile' #{File.join(@@cache_dir, file_name)}.shp)
       arguments << %Q(PG:'host=#{@settings['database']['host']} port=#{@settings['database']['port']} user=#{@settings['database']['username']} dbname=#{allowed_database_name(database_name)} password=#{@settings['database']['password']}')
       arguments << %Q(-sql 'SELECT *,sde.ST_AsText(shape) FROM #{table_name}' -skipfailures)
 
@@ -51,12 +56,14 @@ module Shapefile
     end
 
     def response(request)
-      if File.file?(Rack::Directory.new('public').root + "/export-#{request.params['table']}.zip")
-        file = "export-#{request.params['table']}.zip"
-      else
-        file = zip(to_shp(request.params['table'],request.params['database']))
+      filename = "export-#{request.params['table']}.zip"
+      FileUtils.mkdir_p(@@cache_dir)
+
+      unless File.file?(File.join(@@cache_dir, filename))
+        zip(to_shp(request.params['table'],request.params['database']))
       end
-      [200, {'Content-Type' => 'application/zip', 'Content-Disposition' => "attachment; filename=\"#{request.params['table']}.zip\""}, FileStreamer.new("public/#{file}")]
+
+      [200, {'Content-Type' => 'application/zip', 'Content-Disposition' => "attachment; filename=\"#{filename}\""}, FileStreamer.new(File.join(@@cache_dir, filename))]
     end
 
     def call(env)

--- a/lib/tasks/generate_cache.rb
+++ b/lib/tasks/generate_cache.rb
@@ -4,13 +4,18 @@ require 'active_support/core_ext/hash'
 require 'yaml'
 require 'erb'
 require 'zip'
+require 'fileutils'
+
+CACHE_DIR = 'public/cache'
 
 def zip(file_name)
-  Zip::File.open("public/#{file_name}.zip", Zip::File::CREATE) do |zipfile|
+  file_path = File.join(CACHE_DIR, file_name)
+
+  Zip::File.open("#{file_path}.zip", Zip::File::CREATE) do |zipfile|
     zipfile.add("#{file_name}.prj", "public/26986.prj")
-    zipfile.add("#{file_name}.shp", "public/#{file_name}.shp")
-    zipfile.add("#{file_name}.shx", "public/#{file_name}.shx")
-    zipfile.add("#{file_name}.dbf", "public/#{file_name}.dbf")
+    zipfile.add("#{file_name}.shp", "#{file_path}.shp")
+    zipfile.add("#{file_name}.shx", "#{file_path}.shx")
+    zipfile.add("#{file_name}.dbf", "#{file_path}.dbf")
   end
   return "#{file_name}.zip"
 end
@@ -21,7 +26,7 @@ def to_shp(table_name, database_name)
 
   file_name = "export-#{table_name}"
   arguments = []
-  arguments << %Q(-f 'ESRI Shapefile' public/#{file_name}.shp)
+  arguments << %Q(-f 'ESRI Shapefile' #{File.join(CACHE_DIR, file_name)}.shp)
   arguments << %Q(PG:'host=#{@settings['database']['host']} port=#{@settings['database']['port']} user=#{@settings['database']['username']} dbname=#{database_name} password=#{@settings['database']['password']}')
   arguments << %Q(-sql 'SELECT *,sde.ST_AsText(shape) FROM #{table_name}' -skipfailures)
 
@@ -36,7 +41,7 @@ def to_csv(table_name, database_name)
 
   file_name = "#{table_name}.csv"
   arguments = []
-  arguments << %Q(-c "\\copy (SELECT * FROM #{table_name}) to 'public/#{file_name}' with csv header")
+  arguments << %Q(-c "\\copy (SELECT * FROM #{table_name}) to '#{File.join(CACHE_DIR, file_name)}' with csv header")
   arguments << %Q(-w -h #{@settings['database']['host']} -p #{@settings['database']['port']} -U #{@settings['database']['username']} -d #{database_name})
   arguments << %Q(> log/psql.log 2>&1)
 
@@ -63,6 +68,8 @@ connection = ActiveRecord::Base.establish_connection(
 tables = ActiveRecord::Base.connection.execute("SELECT * FROM tabular._data_browser WHERE db_name = 'gisdata';")
 
 tables.each do |dataset|
+  FileUtils.mkdir_p(CACHE_DIR)
+
   puts "Caching #{dataset['table_name']}"
   zip(to_shp("#{dataset['schemaname']}.#{dataset['table_name']}",dataset['db_name']))
   # to_csv("#{dataset['schemaname']}.#{dataset['table_name']}",dataset['db_name'])

--- a/package.json
+++ b/package.json
@@ -1,5 +1,0 @@
-{
-  "devDependencies": {
-    "babel-plugin-transform-object-rest-spread": "^6.26.0"
-  }
-}


### PR DESCRIPTION
Resolves #193.

# Why is this change necessary?
The original intent of the download was that the browser should only be downloading data by the selectable year filters on the site. 

# How does it address the issue?
It checks for year values before resolving the query arguments. If the `years` and `year_col` params exist, then the data will be filtered by years selected.

# What side effects does it have?
The results of a year query are stored in the warmed cache.