### PR TITLE
Fix the DataBrowser's main app window flex height

### DIFF
--- a/public/assets/styles/partials/_base.scss
+++ b/public/assets/styles/partials/_base.scss
@@ -16,7 +16,7 @@ body {
 }
 
 main {
-  flex: 1 1;
+  flex: 1 1 auto;
 
   padding-bottom: 50px;
 }


### PR DESCRIPTION
Resolves #205 .

# Why is this change necessary?
It doesn't look like it should in IE

# How does it address the issue?
It expands the height of the main app window to expand to height of browser window.
