### PR TITLE
Create temporary blank boxes for 2020

### DIFF
--- a/app/javascript/pages/components/partials/BlankCalendarItem.jsx
+++ b/app/javascript/pages/components/partials/BlankCalendarItem.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+class BlankCalendarItem extends React.Component {
+  render() {
+    return (
+      <li className="calendar-grid__cell">
+        <a href={this.props.link} className="calendar-item"> 
+          <div className="calendar-item__month">{this.props.month}</div>
+          <div className="calendar-item__box--blank">
+            <h3 className="calendar-item__title--blank">Coming Soon</h3>
+          </div>
+        </a>
+      </li>
+    );
+  }
+}
+  
+export default BlankCalendarItem;
+  

--- a/app/javascript/pages/components/partials/CalendarGrid.jsx
+++ b/app/javascript/pages/components/partials/CalendarGrid.jsx
@@ -1,24 +1,42 @@
+/* eslint-disable react/prefer-stateless-function */
 import React from 'react';
 import CalendarItem from './CalendarItem';
+import BlankCalendarItem from './BlankCalendarItem';
 import data from '../../assets/data/temp-cal-data.json';
 
 
 class CalendarGrid extends React.Component {
   render() {
-    const calendarItemsForYear = data.filter((item) => item.year === this.props.selectedYear)
-      .map((item, i) => (
-        <CalendarItem
+    const months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
+    const existingCalendarItems = data.filter((item) => item.year === this.props.selectedYear)
+      .map((item, i) => {
+        months.shift();
+        return <CalendarItem
           link={item.url}
           month={item.month}
           image={item.image}
           title={item.title}
           key={i}
         />
-      ));
+      });
+
+    // Create some number of blank cards
+    const blankCalendarItems = months.map((month, i) => {
+      const blankDisplayMonth = `${month} '${this.props.selectedYear.toString().slice(-2)}`;
+      const keyValue = `b${i}`;
+      return <BlankCalendarItem
+        month={blankDisplayMonth}
+        key={keyValue}
+      />
+    })
+
+    const allCalendarItems = existingCalendarItems.concat(blankCalendarItems);
+  
+
 
     return (
       <ul className="component CalendarGrid container">
-        {calendarItemsForYear}
+        {allCalendarItems}
       </ul>
     );
   }

--- a/app/javascript/styles/components/Calendar.scss
+++ b/app/javascript/styles/components/Calendar.scss
@@ -26,6 +26,24 @@
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.14);
     display: flex;
     flex-direction: column;
+
+    &--blank {
+      align-items: center;
+      background: #B7E2C7;
+      border: 1px solid #B7E2C7;
+      color: #B7E2C7;
+      display: flex;
+      height: 285px;
+      justify-content: center;
+      transition: background .12s, color .12s;
+      width: 100%;
+    }
+
+    &--blank:hover {
+      background: white;
+      color: $color_font-dark;
+      transition: background .12s, color .12s;
+    }
   }
 
   &__box:after {


### PR DESCRIPTION
Resolves # .

# Why is this change necessary?
We needed the full 4x3 grid of calendar items to maintain visual balance in the app and make it clear that this is similar to an advent calendar in function. However, because we want to keep each data story secret before its first-of-the-month release, we needed some new sort of blank box to fill space.

# How does it address the issue?
Styles a new component, BlankCalendarItem (similar to the regular CalendarItem), to show a blank green box and then show "Coming Soon" on hover.

# What side effects does it have?
No side effects, but we may need to adjust this solution slightly when we start reading in the proper backend API.
