### PR TITLE
Standardize calendar box sizes at 250px

### DIFF
--- a/app/javascript/pages/components/Gallery.jsx
+++ b/app/javascript/pages/components/Gallery.jsx
@@ -36,7 +36,7 @@ class Gallery extends React.Component {
     if (this.state.selectedYear === 2020) {
       calendar2020Blurb = (
         <>
-          <section className="container calendar-spotlight tight">
+          <section className="calendar-spotlight">
             <a href='/files/final-mapc-calendar-2020.pdf' download>
               <div className="calendar-spotlight__image-wrapper">
                 <img src={CalendarImg} className="calendar-spotlight__image"/>

--- a/app/javascript/pages/components/Gallery.jsx
+++ b/app/javascript/pages/components/Gallery.jsx
@@ -49,9 +49,9 @@ class Gallery extends React.Component {
               <button className="calendar-spotlight__button"><a href="https://lp.constantcontact.com/su/Vab7XBS">Sign Up</a></button>
             </div>
           </section>
-          <hr className="calendar-spotlight__divider"/>
+          <hr className="calendar-spotlight__divider" />
         </>
-      )
+      );
     }
     return (
       <section className="route Gallery">

--- a/app/javascript/pages/components/partials/CalendarGrid.jsx
+++ b/app/javascript/pages/components/partials/CalendarGrid.jsx
@@ -7,7 +7,7 @@ import data from '../../assets/data/temp-cal-data.json';
 
 class CalendarGrid extends React.Component {
   render() {
-    const months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
+    const months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
     const existingCalendarItems = data.filter((item) => item.year === this.props.selectedYear)
       .map((item, i) => {
         months.shift();
@@ -26,18 +26,17 @@ class CalendarGrid extends React.Component {
     const blankCalendarItems = months.map((month, i) => {
       const blankDisplayMonth = `${month} ${this.props.selectedYear}`;
       const keyValue = `b${i}`;
-      return <BlankCalendarItem
-        month={blankDisplayMonth}
-        key={keyValue}
-      />
-    })
+      return (
+        <BlankCalendarItem
+          month={blankDisplayMonth}
+          key={keyValue}
+        />
+      );
+    });
 
     const allCalendarItems = existingCalendarItems.concat(blankCalendarItems);
-
-
-
     return (
-      <ul className="component CalendarGrid container tight">
+      <ul className="CalendarGrid">
         {allCalendarItems}
       </ul>
     );

--- a/app/javascript/styles/components/Calendar.scss
+++ b/app/javascript/styles/components/Calendar.scss
@@ -1,3 +1,8 @@
+.Gallery {
+  display: flex;
+  flex-direction: column;
+}
+
 .CalendarGrid {
   @include media(large) {
     grid-template-columns: repeat(3, 1fr);
@@ -14,11 +19,12 @@
   @include media(x-small) {
     column-gap: 30px;
   }
-
+  align-self: center;
   display: grid;
   grid-column-gap: 60px;
   grid-row-gap: 60px;
   grid-template-columns: repeat(4, 1fr);
+  max-width: 1180px;
 }
 
 .calendar-item {
@@ -75,15 +81,15 @@
     border-color: $color_brand-secondary--dark;
 
     &:after {
-      left: 6px;
-
       background: $color_brand-secondary--dark;
+      left: 6px;
       transition: background .12s, left .12s;
     }
   }
 
   &__image {
-    height: 185px;
+    height: 175px;
+    object-fit: cover;
     width: 100%;
   }
 
@@ -164,4 +170,8 @@
     display: block;
     margin-top: 3rem;
   }
+}
+
+.calendar-grid__cell {
+  width: 250px;
 }

--- a/app/javascript/styles/components/Spotlights.scss
+++ b/app/javascript/styles/components/Spotlights.scss
@@ -54,7 +54,8 @@
 
   &__divider {
     border: 1rem solid #F5F5F5;
-    margin-bottom: 40px;
+    box-sizing: unset;
+    margin: 0 0 40px 0;
   }
 }
 
@@ -62,25 +63,29 @@
   @include media(large) {
     grid-template-columns: repeat(3, 1fr);
     -ms-grid-columns: 1fr 1fr 1fr;
+    max-width: 870px;
   }
   @include media(medium) {
     grid-template-columns: repeat(2, 1fr);
     -ms-grid-columns: 1fr 1fr;
+    max-width: 560px;
   }
   @include media(small) { column-gap: 60px; }
   @include media(x-small) { column-gap: 30px; }
+  align-self: center;
   column-gap: 60px;
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   display: -ms-grid;
   -ms-grid-columns: 1fr 1fr 1fr 1fr;
   margin-bottom: 60px;
+  max-width: 1180px;
 
   &__image-wrapper {
     grid-column: 1;
     -ms-grid-column: 1;
     position: relative;
-    width: 100%;
+    width: 250px;
     &:hover {
       border-color: #3a9374;
 
@@ -95,7 +100,7 @@
     &::after {
       @extend ._pseudo;
       background: $color_brand-secondary;
-      height: calc(100% - 4px);
+      height: 332px;
       left: 4px;
       position: absolute;
       top: 4px;
@@ -118,7 +123,7 @@
     align-items: center;
     background: rgba(174, 221, 191, .6);
     display: flex;
-    height: calc(100% - 4px);
+    height: 329px;
     justify-content: center;
     left: 0;
     line-height: 2rem;


### PR DESCRIPTION
Resolves #237 .

# Why is this change necessary?
The size of the grid cells was tied to the size of the screen, resulting the calendar boxes to look either stretched or squished depending on the browser size.

# How does it address the issue?
I set an absolute size for the boxes and a `max-width` for the grid itself that is equal to the widths of the squares plus their column margins. Then, I horizontally centered the grid so that there would be equal margins on either side.

# What side effects does it have?
Once the medium screen breakpoint is hit (960px)/the layout goes to two columns, the leftmost image is shorter than the rightmost text, which we tried to avoid:

![Screen Shot 2019-12-30 at 11 28 29 AM](https://user-images.githubusercontent.com/10645500/71590777-c2b2ae00-2af7-11ea-9e78-5ab6ac3289b2.png)

However, this doesn't seem to impact mobile (everything is just scaled down and shows in a 3-column layout). Fixing this would require either reworking the box sizes at various breakpoints or having inconsistent margins at this breakpoint, as the space between image and text should reflect the space between calendar items.