### PR TITLE
Standardize margins of top two homepage sections

### DIFF
--- a/app/javascript/pages/components/Home.jsx
+++ b/app/javascript/pages/components/Home.jsx
@@ -10,7 +10,6 @@ import PlaybackImgBackground from './../assets/images/playback-bg';
 import PlaybackImg from './../assets/images/playback';
 
 class Home extends React.Component {
-
   constructor() {
     super(...arguments);
 
@@ -62,12 +61,10 @@ class Home extends React.Component {
 
         <section className="container tight gallery-spotlight page-section">
           <div className="gallery-spotlight__info">
-            <h2>Gallery of Data</h2>
-            <p>Welcome to the MAPC Gallery of Data, where we tell the story of Greater Boston’s most complex issues — one monthly map and data visualization at a time. We look at a range of vital and interrelated topics: equity, housing, transportation, climate, arts and culture, and more. </p>
-            <p>Always with data first, and always with an interdisciplinary lens. Visit every month to see what’s new!</p>
-            <button className="gallery-spotlight__button" type="button">
-              <a href="/gallery">View Gallery</a>
-            </button>
+            <h2 className="gallery-spotlight__title">Gallery of Data</h2>
+            <p>Welcome to the MAPC Gallery of Data, where we tell the story of Greater Boston’s most complex issues — one monthly map and data visualization at a time. We look at a range of vital and interrelated topics: equity, housing, transportation, climate, arts and culture, and more. Always with data first, and always with an interdisciplinary lens.</p>
+            <p>Visit every month to see what’s new!</p>
+            <button className="gallery-spotlight__button"><a href="/gallery">View Gallery</a></button>
 
           </div>
           <Link to="/calendar/2020/january">

--- a/app/javascript/styles/components/Spotlights.scss
+++ b/app/javascript/styles/components/Spotlights.scss
@@ -159,6 +159,9 @@
   display: -ms-grid;
   -ms-grid-columns: 1fr 1fr 1fr 1fr 1fr;
 
+  &__title {
+    margin-left: -20px;
+  }
 
   &__image {
     height: 20rem;
@@ -182,6 +185,7 @@
     }
     grid-column: 5;
     -ms-grid-column: 5;
+    padding-right: 20px;
   }
 
   &__info {
@@ -203,5 +207,6 @@
     grid-column: 1 / 5;
     -ms-grid-column-span: 4;
     -ms-grid-row: 1;
+    margin: 0 20px 60px 20px;
 	}
 }


### PR DESCRIPTION
Resolves #233 .

# Why is this change necessary?
Kit and I previously discussed the margins on the homepage and how to get as much standardization in as possible, and she suggested using the "Data by category" section as the standard. Implementing that on "Community Profiles" will be a bit tricky due to absolute positioning, but implementing it for "Gallery of Data" just required a little bit of margin manipulation to create the indented look of the text.

# How does it address the issue?
Set the default margins to match the category grid and then set negative margins on the title.

# What side effects does it have?
It shouldn't have any, but I could see something coming up when we swap out the tall poster image for the longer bar chart race screenshot.
