### PR TITLE
Change SVG draw order so text goes on top of axes

### DIFF
--- a/app/javascript/pages/components/Calendar.jsx
+++ b/app/javascript/pages/components/Calendar.jsx
@@ -173,8 +173,8 @@ class Calendar extends React.Component {
       }
 
       const updateBars = bars(svg);
-      const updateLabels = labels(svg);
       const updateAxis = axis(svg);
+      const updateLabels = labels(svg);
       const updateTicker = ticker(svg);
 
       async function codeToRun() {


### PR DESCRIPTION
Resolves #240 .

# Why is this change necessary?
With the industry titles off to the right side of each bar, having the axes layer over the text was breaking some of the illusion of the race, resulting in an awkward user experience.

# How does it address the issue?
Moved the function call `labels` after the call to `axis` so that the text would be drawn onto the SVG on top of the axes, no CSS required.

# What side effects does it have?
None; the two functions work independently of one another.