### PR TITLE
Change images to reflect latest

### DIFF
--- a/app/javascript/pages/components/Home.jsx
+++ b/app/javascript/pages/components/Home.jsx
@@ -6,8 +6,8 @@ import Particles from './partials/Particles';
 import SearchBar from '../containers/SearchBar';
 import CategoryGrid from '../containers/CategoryGrid';
 import CommunitySelector from '../containers/CommunitySelector';
-import PlaybackImgBackground from './../assets/images/playback-bg';
-import PlaybackImg from './../assets/images/playback';
+import PlaybackImgBackground from './../assets/images/gallery_7';
+import PlaybackImg from './../assets/images/gallery_8';
 
 class Home extends React.Component {
   constructor() {

--- a/app/javascript/styles/components/Spotlights.scss
+++ b/app/javascript/styles/components/Spotlights.scss
@@ -169,8 +169,8 @@
   }
 
   &__image {
-    height: 20rem;
-    width: auto;
+    height: auto;
+    width: 30rem;
 
     @include media(medium) {
       grid-column: 4;


### PR DESCRIPTION
Resolves # .
Image for January 2020 data viz was outdated.

# Why is this change necessary?
Image for January 2020 data viz was outdated.

# How does it address the issue?
* Point default and background images to updated screenshots
* Set width to prevent text jumping

# What side effects does it have?
None