### PR TITLE
Add Working URL Routes

### DIFF
--- a/app/javascript/pages/components/App.jsx
+++ b/app/javascript/pages/components/App.jsx
@@ -32,6 +32,7 @@ const App = (props) => (
         <Route exact path="/gallery" component={Gallery} />
         <Route exact path="/login" component={Login} />
         <Route path='/calendar/:year/:month' component={Calendar} />
+        <Route path='/browser/:menuOneSelectedItem' component={Browser} />
         <Route path='/browser' component={Browser} />
         <PrivateRoute exact path="/admin" component={Admin} />
       </Switch>

--- a/app/javascript/pages/components/Browser.jsx
+++ b/app/javascript/pages/components/Browser.jsx
@@ -74,9 +74,9 @@ class Browser extends React.Component {
         <div className="page-header">
           <div className="container tight">
             <SearchBar
-              contextKey={'dataset'}
-              searchColumn={'title'}
-              action={selected => this.toDataset(selected)}
+              contextKey="dataset"
+              searchColumn="title"
+              action={(selected) => this.toDataset(selected)}
               placeholder={`Search ${this.props.datasets.length} datasets ...`}
             />
           </div>
@@ -84,8 +84,19 @@ class Browser extends React.Component {
         <div className="category-lists">
           <div className="container tight">
             <DataMenu items={items} datasets={this.props.datasets} onMenuClick={this.handleMenuSelectedItem('menuOneSelectedItem')} />
-            {items.length > 0 && menuOneSelectedItem ? <DataMenu datasets={this.props.datasets} items={items.filter(item => item.menuTitle === menuOneSelectedItem)[0].items} onMenuClick={this.handleMenuSelectedItem('menuTwoSelectedItem')} /> : null}
-            {items.length > 0 && menuTwoSelectedItem ? <DataMenu items={items.filter(item => item.menuTitle === menuOneSelectedItem)[0].items.filter(item => item.menuTitle === menuTwoSelectedItem)[0].items} onDatasetClick={this.handleDatasetClick()} /> : null}
+            {items.length > 0 && menuOneSelectedItem ? (
+              <DataMenu
+                datasets={this.props.datasets}
+                items={items.filter((item) => item.menuTitle === menuOneSelectedItem)[0].items}
+                onMenuClick={this.handleMenuSelectedItem('menuTwoSelectedItem')}
+              />
+            ) : null}
+            {items.length > 0 && menuTwoSelectedItem ? (
+              <DataMenu
+                items={items.filter((item) => item.menuTitle === menuOneSelectedItem)[0].items.filter((item) => item.menuTitle === menuTwoSelectedItem)[0].items}
+                onDatasetClick={this.handleDatasetClick()}
+              />
+            ) : null}
           </div>
         </div>
       </section>

--- a/app/javascript/pages/components/Browser.jsx
+++ b/app/javascript/pages/components/Browser.jsx
@@ -7,7 +7,9 @@ import DataMenu from './partials/DataMenu';
 class Browser extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {};
+    this.state = {
+      menuOneSelectedItem: this.props.match.params.menuOneSelectedItem,
+    };
 
     this.toDataset = this.toDataset.bind(this);
   }
@@ -82,8 +84,8 @@ class Browser extends React.Component {
         <div className="category-lists">
           <div className="container tight">
             <DataMenu items={items} datasets={this.props.datasets} onMenuClick={this.handleMenuSelectedItem('menuOneSelectedItem')} />
-            {menuOneSelectedItem ? <DataMenu datasets={this.props.datasets} items={items[menuOneSelectedItem].items} onMenuClick={this.handleMenuSelectedItem('menuTwoSelectedItem')} /> : null}
-            {menuTwoSelectedItem ? <DataMenu items={items[menuOneSelectedItem].items[menuTwoSelectedItem].items} onDatasetClick={this.handleDatasetClick()} /> : null}
+            {items.length > 0 && menuOneSelectedItem ? <DataMenu datasets={this.props.datasets} items={items.filter(item => item.menuTitle === menuOneSelectedItem)[0].items} onMenuClick={this.handleMenuSelectedItem('menuTwoSelectedItem')} /> : null}
+            {items.length > 0 && menuTwoSelectedItem ? <DataMenu items={items.filter(item => item.menuTitle === menuOneSelectedItem)[0].items.filter(item => item.menuTitle === menuTwoSelectedItem)[0].items} onDatasetClick={this.handleDatasetClick()} /> : null}
           </div>
         </div>
       </section>

--- a/app/javascript/pages/components/partials/DataMenu.jsx
+++ b/app/javascript/pages/components/partials/DataMenu.jsx
@@ -11,7 +11,7 @@ export default function DataMenu(props) {
       <h3>Topics</h3>
       <ul className="styled lift">
         { props.items.map((item, index) => (
-          <li className='menu-item' onClick={item.items ? props.onMenuClick : props.onDatasetClick} key={index} data-key={item.dataset ? item.dataset.seq_id : index}>
+          <li className='menu-item' onClick={item.items ? props.onMenuClick : props.onDatasetClick} key={index} data-key={item.dataset ? item.dataset.seq_id : item.menuTitle}>
             <div className="category-item-content">
               <div className="category-item-column">{item.menuTitle}</div>
               <div className="menu-item__dataset-count">{item.items ? datasetCount(item) : null}</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,4 +10,5 @@ Rails.application.routes.draw do
   get '/calendar/*date', to: 'pages#index'
   get '/browser', to: 'pages#index'
   get '/browser/datasets/*dataset', to: 'pages#index'
+  get '/browser/*menuOneSelectedItem', to: 'pages#index'
 end


### PR DESCRIPTION
In order for the front page to be able to link to a cageory of datasets, we needed to add a feature to set state based on the URL. This commit accomplishes that goal by adding a route to capture the url segement the Ember application used to display the menu, and then set the state for the first menu selection based on that value.
