### PR TITLE
Att/255 edge cases

### DIFF
--- a/app/javascript/pages/components/DataViewer.jsx
+++ b/app/javascript/pages/components/DataViewer.jsx
@@ -34,7 +34,7 @@ export default class DataViewer extends React.Component {
             rows: tableResults.data.rows,
             universe: metadata.filter((row) => row.name === 'universe')[0].details,
             description: metadata.filter((row) => row.name === 'descriptn')[0].details,
-            columnKeys: Object.keys(tableResults.data.rows[0]),
+            columnKeys: Object.keys(tableResults.data.rows[0]).filter((header) => header !== 'seq_id'),
             metadata,
             selectedYears: [yearResults.data.rows.map((year) => Object.values(year)[0]).sort().reverse()[0]],
             table: dataset.table_name,
@@ -49,7 +49,8 @@ export default class DataViewer extends React.Component {
         const queryToken = '1b9b9a1d1738c3dce14331040fa17008';
         const tableQuery = axios.get(`${queryBase}?query=select%20*%20from%20${dataset.schemaname}.${dataset.table_name}%20%20LIMIT%2050;&token=${queryToken}`);
         const headerQuery = axios.get(`/${dataset.db_name}?tables=${dataset.table_name}`);
-        axios.all([tableQuery, headerQuery]).then((response) => {
+        const test = axios.get("https://prql.mapc.org/?token=16a2637ee33572e46f5609a578b035dc&query=SELECT%20*%20FROM%20tabular._data_browser%20WHERE%20active%20%3D%20%27Y%27%20ORDER%20BY%20menu1,menu2,menu3%20ASC")
+        axios.all([tableQuery, headerQuery, test]).then((response) => {
           const tableResults = response[0];
           const metadata = Object.values(response[1].data)[0];
           this.setState({

--- a/app/javascript/pages/components/DataViewer.jsx
+++ b/app/javascript/pages/components/DataViewer.jsx
@@ -49,8 +49,7 @@ export default class DataViewer extends React.Component {
         const queryToken = '1b9b9a1d1738c3dce14331040fa17008';
         const tableQuery = axios.get(`${queryBase}?query=select%20*%20from%20${dataset.schemaname}.${dataset.table_name}%20%20LIMIT%2050;&token=${queryToken}`);
         const headerQuery = axios.get(`/${dataset.db_name}?tables=${dataset.table_name}`);
-        const test = axios.get("https://prql.mapc.org/?token=16a2637ee33572e46f5609a578b035dc&query=SELECT%20*%20FROM%20tabular._data_browser%20WHERE%20active%20%3D%20%27Y%27%20ORDER%20BY%20menu1,menu2,menu3%20ASC")
-        axios.all([tableQuery, headerQuery, test]).then((response) => {
+        axios.all([tableQuery, headerQuery]).then((response) => {
           const tableResults = response[0];
           const metadata = Object.values(response[1].data)[0];
           this.setState({

--- a/app/javascript/pages/components/DataViewer.jsx
+++ b/app/javascript/pages/components/DataViewer.jsx
@@ -56,11 +56,12 @@ export default class DataViewer extends React.Component {
             rows: tableResults.data.rows,
             columnKeys: Object.keys(tableResults.data.rows[0]).filter((header) => header !== 'shape'),
             metadata,
-            // schema,
-            // database,
-            // title,
-            // source,
-            // queryYearColumn,
+            description: metadata.documentation.metadata.dataIdInfo.idPurp,
+            schema: dataset.schemaname,
+            source: dataset.source,
+            database: dataset.db_name,
+            table: dataset.table_name,
+            title: dataset.menu3,
           });
         });
       }
@@ -118,7 +119,6 @@ export default class DataViewer extends React.Component {
           currentPage={this.state.currentPage}
           columnKeys={this.state.columnKeys}
           rows={this.state.rows}
-          columnKeys={this.state.columnKeys}
           queryYearColumn={this.state.queryYearColumn}
           selectedYears={this.state.selectedYears}
           updatePage={this.updatePage}

--- a/app/javascript/pages/components/partials/DataRow.jsx
+++ b/app/javascript/pages/components/partials/DataRow.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
 const DataRow = ({ headers, rowData }) => {
-  const renderedRow = headers.map((header) => <td key={header}>{rowData[header]}</td>);
+  const renderedRow = headers.filter((header) => header !== 'seq_id')
+    .map((header) => <td key={header}>{rowData[header]}</td>);
   return <tr>{renderedRow}</tr>;
 };
 

--- a/app/javascript/pages/components/partials/DatasetHeader.jsx
+++ b/app/javascript/pages/components/partials/DatasetHeader.jsx
@@ -87,6 +87,18 @@ function setSelectYears(availableYears, updateSelectedYears, selectedYears) {
   return null;
 }
 
+function setUniverse(universe) {
+  if (universe) {
+    return (
+      <li>
+        Universe:
+        <em>{` ${universe}`}</em>
+      </li>
+    );
+  }
+  return null;
+}
+
 function DatasetHeader({
   title, table, source, universe, description, availableYears, metadata, schema, database, updateSelectedYears, queryYearColumn, selectedYears,
 }) {
@@ -108,10 +120,7 @@ function DatasetHeader({
                 Source:
                 <em>{` ${source}`}</em>
               </li>
-              <li>
-                Universe:
-                <em>{` ${universe}`}</em>
-              </li>
+              { setUniverse(universe) }
               <li>
                 Description:
                 <em>{` ${description}`}</em>

--- a/app/javascript/pages/components/partials/DatasetTable.jsx
+++ b/app/javascript/pages/components/partials/DatasetTable.jsx
@@ -19,10 +19,13 @@ function setTableHeaders(columnKeys, metadata) {
     ));
 }
 
-function DatasetTable({ rows, columnKeys, queryYearColumn, currentPage, selectedYears, updatePage, metadata }) {
+function DatasetTable({
+  columnKeys, currentPage, metadata, queryYearColumn, rows, selectedYears, updatePage,
+}) {
   const renderedHeaders = setTableHeaders(columnKeys, metadata);
   const allRows = rows.filter((row) => selectedYears.includes(row[queryYearColumn]))
     .map((row) => <DataRow key={row.seq_id} rowData={row} headers={columnKeys} />);
+
   const renderedRows = allRows.slice((currentPage - 1) * 50, currentPage * 50);
   const numOfPages = Math.ceil(allRows.length / 50);
   const backButtonClasses = currentPage === 1 ? 'button-wrapper lift disabled' : 'button-wrapper lift';
@@ -91,21 +94,21 @@ function DatasetTable({ rows, columnKeys, queryYearColumn, currentPage, selected
 }
 
 DatasetTable.propTypes = {
+  columnKeys: PropTypes.arrayOf(PropTypes.string),
   currentPage: PropTypes.number,
-  displayHeaders: PropTypes.arrayOf(PropTypes.string),
+  metadata: PropTypes.arrayOf(PropTypes.object),
   queryYearColumn: PropTypes.string,
   rows: PropTypes.arrayOf(PropTypes.object),
-  rowHeaders: PropTypes.arrayOf(PropTypes.string),
   selectedYears: PropTypes.arrayOf(PropTypes.string),
   updatePage: PropTypes.func.isRequired,
 };
 
 DatasetTable.defaultProps = {
+  columnKeys: [],
   currentPage: 1,
-  displayHeaders: [],
+  metadata: [{ example: '123', }],
   queryYearColumn: '',
   rows: [],
-  rowHeaders: [],
   selectedYears: [],
 };
 

--- a/app/javascript/pages/components/partials/DatasetTable.jsx
+++ b/app/javascript/pages/components/partials/DatasetTable.jsx
@@ -23,8 +23,13 @@ function DatasetTable({
   columnKeys, currentPage, metadata, queryYearColumn, rows, selectedYears, updatePage,
 }) {
   const renderedHeaders = setTableHeaders(columnKeys, metadata);
-  const allRows = rows.filter((row) => selectedYears.includes(row[queryYearColumn]))
-    .map((row) => <DataRow key={row.seq_id} rowData={row} headers={columnKeys} />);
+  let allRows;
+  if (queryYearColumn) {
+    allRows = rows.filter((row) => selectedYears.includes(row[queryYearColumn]))
+      .map((row) => <DataRow key={row.seq_id} rowData={row} headers={columnKeys} />);
+  } else {
+    allRows = rows.map((row, i) => <DataRow key={i} rowData={row} headers={columnKeys} />);
+  }
 
   const renderedRows = allRows.slice((currentPage - 1) * 50, currentPage * 50);
   const numOfPages = Math.ceil(allRows.length / 50);
@@ -96,7 +101,10 @@ function DatasetTable({
 DatasetTable.propTypes = {
   columnKeys: PropTypes.arrayOf(PropTypes.string),
   currentPage: PropTypes.number,
-  metadata: PropTypes.arrayOf(PropTypes.object),
+  metadata: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.object),
+    PropTypes.objectOf(PropTypes.object),
+  ]),
   queryYearColumn: PropTypes.string,
   rows: PropTypes.arrayOf(PropTypes.object),
   selectedYears: PropTypes.arrayOf(PropTypes.string),
@@ -106,7 +114,7 @@ DatasetTable.propTypes = {
 DatasetTable.defaultProps = {
   columnKeys: [],
   currentPage: 1,
-  metadata: [{ example: '123', }],
+  metadata: [],
   queryYearColumn: '',
   rows: [],
   selectedYears: [],

--- a/app/javascript/pages/components/partials/DatasetTable.jsx
+++ b/app/javascript/pages/components/partials/DatasetTable.jsx
@@ -26,7 +26,7 @@ function DatasetTable({
   let allRows;
   if (queryYearColumn) {
     allRows = rows.filter((row) => selectedYears.includes(row[queryYearColumn]))
-      .map((row) => <DataRow key={row.seq_id} rowData={row} headers={columnKeys} />);
+      .map((row, i) => <DataRow key={i} rowData={row} headers={columnKeys} />);
   } else {
     allRows = rows.map((row, i) => <DataRow key={i} rowData={row} headers={columnKeys} />);
   }

--- a/app/javascript/pages/components/partials/DatasetTable.jsx
+++ b/app/javascript/pages/components/partials/DatasetTable.jsx
@@ -2,14 +2,27 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import DataRow from './DataRow';
 
-function DatasetTable({
-  currentPage, displayHeaders, queryYearColumn, rows, rowHeaders, selectedYears, updatePage
-}) {
-  const filteredHeaders = displayHeaders.filter((header) => header !== 'shape');
-  const updatedRowHeaders = rowHeaders.filter((header) => header !== 'shape');
-  const renderedHeaders = filteredHeaders.map((header) => <th className="ui table " key={header}>{header}</th>);
+function setTableHeaders(columnKeys, metadata) {
+  if (metadata.documentation) {
+    return columnKeys.map((header) => (
+      <th className="ui table" key={header}>
+        {header}
+      </th>
+    ));
+  }
+  return columnKeys
+    .filter((header) => metadata.find((element) => element.name === header))
+    .map((header) => (
+      <th className="ui table" key={header}>
+        { metadata.find((element) => element.name === header).alias }
+      </th>
+    ));
+}
+
+function DatasetTable({ rows, columnKeys, queryYearColumn, currentPage, selectedYears, updatePage, metadata }) {
+  const renderedHeaders = setTableHeaders(columnKeys, metadata);
   const allRows = rows.filter((row) => selectedYears.includes(row[queryYearColumn]))
-    .map((row) => <DataRow key={row.seq_id} rowData={row} headers={updatedRowHeaders} />);
+    .map((row) => <DataRow key={row.seq_id} rowData={row} headers={columnKeys} />);
   const renderedRows = allRows.slice((currentPage - 1) * 50, currentPage * 50);
   const numOfPages = Math.ceil(allRows.length / 50);
   const backButtonClasses = currentPage === 1 ? 'button-wrapper lift disabled' : 'button-wrapper lift';


### PR DESCRIPTION
Resolves #255.

# Why is this change necessary?
Because spatial and tabular datasets are formatted differently, they need different methods for generating .csv data file and metadata files. Additionally, spatial datasets needed .shp download buttons.

# How does it address the issue?
Conditionals everywhere! Depending on whether or not a dataset pulls metadata from the `ds` table or `towndata` table, the .shp button will render and clicking the other two download buttons will run the proper data aggregation code. 

# What side effects does it have?
There are two additional pieces that I fit into this PR:
1) I removed `seq_id` from the data viewer to accommodate for datasets with sequence id data, but don't have that in the headers. It is still available in the data download, and any React elements that were generated with `seq_id` as a key are now using the array index as a key.
2) The "universe" metadata tag isn't available for all datasets, so I'm conditionally rendering that as well.

This doesn't resolve the spatial metadata issue brought up in #250, but I think that that should be handled in a separate PR so as not to complicate the Ember-to-React migration.
