### PR TITLE
Resolve #257 Fix Column Ordering

### DIFF
--- a/app/javascript/pages/components/DataViewer.jsx
+++ b/app/javascript/pages/components/DataViewer.jsx
@@ -34,7 +34,9 @@ export default class DataViewer extends React.Component {
             rows: tableResults.data.rows,
             universe: metadata.filter((row) => row.name === 'universe')[0].details,
             description: metadata.filter((row) => row.name === 'descriptn')[0].details,
-            columnKeys: Object.keys(tableResults.data.rows[0]).filter((header) => header !== 'seq_id'),
+            columnKeys: metadata.filter((object) => Object.keys(tableResults.data.rows[0]).includes(object.name))
+              .map((header) => header.name)
+              .filter((header) => header !== 'seq_id'),
             metadata,
             selectedYears: [yearResults.data.rows.map((year) => Object.values(year)[0]).sort().reverse()[0]],
             table: dataset.table_name,
@@ -52,9 +54,13 @@ export default class DataViewer extends React.Component {
         axios.all([tableQuery, headerQuery]).then((response) => {
           const tableResults = response[0];
           const metadata = Object.values(response[1].data)[0];
+          const columns = Object.keys(tableResults.data.rows[0]);
+          const sortedMetadata = metadata.documentation.metadata.eainfo.detailed.attr.map((attribute) => ({ label: attribute.attrlabl, alias: attribute.attalias }))
+            .filter((header) => columns.includes(header.label))
+            .filter((header) => header.label !== 'shape');
           this.setState({
             rows: tableResults.data.rows,
-            columnKeys: Object.keys(tableResults.data.rows[0]).filter((header) => header !== 'shape'),
+            columnKeys: sortedMetadata,
             metadata,
             description: metadata.documentation.metadata.dataIdInfo.idPurp,
             schema: dataset.schemaname,

--- a/app/javascript/pages/components/DataViewer.jsx
+++ b/app/javascript/pages/components/DataViewer.jsx
@@ -35,8 +35,7 @@ export default class DataViewer extends React.Component {
             universe: metadata.filter((row) => row.name === 'universe')[0].details,
             description: metadata.filter((row) => row.name === 'descriptn')[0].details,
             columnKeys: metadata.filter((object) => Object.keys(tableResults.data.rows[0]).includes(object.name))
-              .map((header) => header.name)
-              .filter((header) => header !== 'seq_id'),
+              .filter((header) => header.name !== 'seq_id'),
             metadata,
             selectedYears: [yearResults.data.rows.map((year) => Object.values(year)[0]).sort().reverse()[0]],
             table: dataset.table_name,
@@ -55,9 +54,9 @@ export default class DataViewer extends React.Component {
           const tableResults = response[0];
           const metadata = Object.values(response[1].data)[0];
           const columns = Object.keys(tableResults.data.rows[0]);
-          const sortedMetadata = metadata.documentation.metadata.eainfo.detailed.attr.map((attribute) => ({ label: attribute.attrlabl, alias: attribute.attalias }))
-            .filter((header) => columns.includes(header.label))
-            .filter((header) => header.label !== 'shape');
+          const sortedMetadata = metadata.documentation.metadata.eainfo.detailed.attr.map((attribute) => ({ name: attribute.attrlabl, alias: attribute.attalias }))
+            .filter((header) => columns.includes(header.name))
+            .filter((header) => header.name !== 'shape');
           this.setState({
             rows: tableResults.data.rows,
             columnKeys: sortedMetadata,

--- a/app/javascript/pages/components/partials/DatasetTable.jsx
+++ b/app/javascript/pages/components/partials/DatasetTable.jsx
@@ -2,33 +2,24 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import DataRow from './DataRow';
 
-function setTableHeaders(columnKeys, metadata) {
-  if (metadata.documentation) {
-    return columnKeys.map((header) => (
-      <th className="ui table" key={header.alias}>
-        {header.alias}
-      </th>
-    ));
-  }
-  return columnKeys
-    .filter((header) => metadata.find((element) => element.name === header))
-    .map((header) => (
-      <th className="ui table" key={header}>
-        { metadata.find((element) => element.name === header).alias }
-      </th>
-    ));
+function setTableHeaders(columnKeys) {
+  return columnKeys.map((header) => (
+    <th className="ui table" key={header.alias}>
+      {header.alias}
+    </th>
+  ));
 }
 
 function DatasetTable({
   columnKeys, currentPage, metadata, queryYearColumn, rows, selectedYears, updatePage,
 }) {
-  const renderedHeaders = setTableHeaders(columnKeys, metadata);
+  const renderedHeaders = setTableHeaders(columnKeys);
   let allRows;
   if (queryYearColumn) {
     allRows = rows.filter((row) => selectedYears.includes(row[queryYearColumn]))
-      .map((row, i) => <DataRow key={i} rowData={row} headers={columnKeys.map((key) => key.label)} />);
+      .map((row, i) => <DataRow key={i} rowData={row} headers={columnKeys.map((key) => key.name)} />);
   } else {
-    allRows = rows.map((row, i) => <DataRow key={i} rowData={row} headers={columnKeys.map((key) => key.label)} />);
+    allRows = rows.map((row, i) => <DataRow key={i} rowData={row} headers={columnKeys.map((key) => key.name)} />);
   }
 
   const renderedRows = allRows.slice((currentPage - 1) * 50, currentPage * 50);

--- a/app/javascript/pages/components/partials/DatasetTable.jsx
+++ b/app/javascript/pages/components/partials/DatasetTable.jsx
@@ -5,8 +5,8 @@ import DataRow from './DataRow';
 function setTableHeaders(columnKeys, metadata) {
   if (metadata.documentation) {
     return columnKeys.map((header) => (
-      <th className="ui table" key={header}>
-        {header}
+      <th className="ui table" key={header.alias}>
+        {header.alias}
       </th>
     ));
   }
@@ -26,9 +26,9 @@ function DatasetTable({
   let allRows;
   if (queryYearColumn) {
     allRows = rows.filter((row) => selectedYears.includes(row[queryYearColumn]))
-      .map((row, i) => <DataRow key={i} rowData={row} headers={columnKeys} />);
+      .map((row, i) => <DataRow key={i} rowData={row} headers={columnKeys.map((key) => key.label)} />);
   } else {
-    allRows = rows.map((row, i) => <DataRow key={i} rowData={row} headers={columnKeys} />);
+    allRows = rows.map((row, i) => <DataRow key={i} rowData={row} headers={columnKeys.map((key) => key.label)} />);
   }
 
   const renderedRows = allRows.slice((currentPage - 1) * 50, currentPage * 50);
@@ -99,7 +99,7 @@ function DatasetTable({
 }
 
 DatasetTable.propTypes = {
-  columnKeys: PropTypes.arrayOf(PropTypes.string),
+  columnKeys: PropTypes.arrayOf(PropTypes.object),
   currentPage: PropTypes.number,
   metadata: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.object),


### PR DESCRIPTION
This commit fixes the column ordering by summoning the order of columns from the relevant metadata and then mapping it to the actual columns available from the dataset.
