### PR TITLE
Responsive Bar Chart Race

### DIFF
--- a/app/javascript/pages/components/Calendar.jsx
+++ b/app/javascript/pages/components/Calendar.jsx
@@ -15,7 +15,7 @@ class Calendar extends React.Component {
         employees: +d.avgemp,
       })),
     ]).then((employmentData) => {
-      const filteredData = employmentData[0].filter(d => d.municipality === 'MAPC Region')
+      const filteredData = employmentData[0].filter((d) => d.municipality === 'MAPC Region')
         .filter((d) => d.category !== 'Total, All Industries');
 
       const employmentByDate = Array.from(rollup(filteredData,
@@ -30,9 +30,13 @@ class Calendar extends React.Component {
       const width = window.innerWidth || document.body.clientWidth;
       let margin;
       if (width > 500) {
-        margin = ({ top: 16, right: 450, bottom: 6, left: 0 });
+        margin = ({
+          top: 16, right: 450, bottom: 6, left: 0,
+        });
       } else {
-        margin = ({ top: 16, right: 0, bottom: 6, left: 0 });
+        margin = ({
+          top: 16, right: 0, bottom: 6, left: 0,
+        });
       }
       const height = (barSize * topResults) + margin.top + margin.bottom;
 
@@ -72,8 +76,8 @@ class Calendar extends React.Component {
 
       const allKeyframes = keyframes(employmentByDate);
       const nameframes = groups(allKeyframes.flatMap(([, data]) => data), (d) => d.category);
-      let prev = new Map(nameframes.flatMap(([, data]) => d3.pairs(data, (a, b) => [b, a])));
-      let next = new Map(nameframes.flatMap(([, data]) => d3.pairs(data)));
+      const prev = new Map(nameframes.flatMap(([, data]) => d3.pairs(data, (a, b) => [b, a])));
+      const next = new Map(nameframes.flatMap(([, data]) => d3.pairs(data)));
 
       const x = d3.scaleLinear([0, 1], [margin.left, width - (margin.right)]);
 
@@ -109,7 +113,7 @@ class Calendar extends React.Component {
 
       function textTween(a, b) {
         const i = d3.interpolateNumber(a, b);
-        return function(t) {
+        return function (t) {
           this.textContent = d3.format(',d')(i(t));
         };
       }
@@ -123,31 +127,31 @@ class Calendar extends React.Component {
           .selectAll('text');
 
         return ([date, data], transition) => label = label
-          .data(data.slice(0, topResults), d => d.category)
+          .data(data.slice(0, topResults), (d) => d.category)
           .join(
             (enter) => enter.append('text')
-              .attr('transform', d => `translate(${x((prev.get(d) || d).value)},${y((prev.get(d) || d).rank)})`)
+              .attr('transform', (d) => `translate(${x((prev.get(d) || d).value)},${y((prev.get(d) || d).rank)})`)
               .attr('x', 6)
               .attr('y', y.bandwidth() / 1.55)
               .attr('dy', '0.1em')
               .style('font-weight', 'lighter')
               .style('fill', '#1F4E46')
-              .text(d => d.category)
-              .call(text => text.append('tspan')
-              .style('font-variant-numeric', 'tabular-nums')
-              .attr('text-anchor', 'end')
-              .attr('fill', '#FFFFFF')
-              .attr('x', -6)
-              .attr('y', 6)
-              .attr('dy', '1em')),
+              .text((d) => d.category)
+              .call((text) => text.append('tspan')
+                .style('font-variant-numeric', 'tabular-nums')
+                .attr('text-anchor', 'end')
+                .attr('fill', '#FFFFFF')
+                .attr('x', -6)
+                .attr('y', 6)
+                .attr('dy', '1em')),
             (update) => update,
             (exit) => exit.transition(transition).remove()
-              .attr('transform', d => `translate(${x((next.get(d) || d).value)},${y((next.get(d) || d).rank)})`)
-              .call(g => g.select('tspan').tween('text', d => textTween(d.value, (next.get(d) || d).value)))
+              .attr('transform', (d) => `translate(${x((next.get(d) || d).value)},${y((next.get(d) || d).rank)})`)
+              .call((g) => g.select('tspan').tween('text', (d) => textTween(d.value, (next.get(d) || d).value))),
           )
           .call((bar) => bar.transition(transition)
-            .attr('transform', d => `translate(${x(d.value)},${y(d.rank)})`)
-            .call(g => g.select('tspan').tween('text', d => textTween((prev.get(d) || d).value, d.value))))
+            .attr('transform', (d) => `translate(${x(d.value)},${y(d.rank)})`)
+            .call((g) => g.select('tspan').tween('text', (d) => textTween((prev.get(d) || d).value, d.value))));
       }
 
       function axis(svg) {
@@ -211,7 +215,7 @@ class Calendar extends React.Component {
         .attr('visibility', 'hidden');
 
       replay.append('image')
-        .attr('href', refresh )
+        .attr('href', refresh)
         .attr('class', 'replay__image')
         .attr('width', 64)
         .attr('height', 64)
@@ -250,14 +254,14 @@ class Calendar extends React.Component {
   }
 
   render() {
-    const back = "<< Back to 2020 Gallery"
+    const back = '<< Back to 2020 Gallery';
     return (
       <section className="route Calendar">
         <div className="container">
           <a href="/gallery" className="back-link">{back}</a>
           <h1 className="jobs__title">Employment by Industry</h1>
           <div className="jobs" />
-          <h2 className="jobs__subtitle"></h2>
+          <h2 className="jobs__subtitle" />
           <div className="container jobs__explanation">
             <p>Metro Boston has experienced rapid economic growth over the past two decades. Although the region experienced periods of employment decline during the 2001 and 2008 national recessions, its employment today is 10% above its previous peak set in 2001. Its top three employing industries since 2001—Professional and Technical Services, Educational Services, and Food Services and Drinking Places—together grew 38% from 2001 to 2018. Healthcare and social assistance industries account for a quarter of jobs among the region’s top 15 industries in 2018, and have seen 89% job growth since 2001. Jobs in Social Assistance, such as those in individual and family services and child day care, were the fastest growing among the region’s top 15, at 116%.</p>
             <p>Average wages in the region across all industries grew 15% (in real dollars) between 2001 and 2018. Yet, looking at wages in the region’s largest individual industries, wage growth has been polarized. Average weekly wages in Social Assistance—the top growing industry among the top 15—declined 4% from an already low $662 per week to $638, in 2018 dollars. Wages in Food Services and Drinking Places, the third largest industry and that with the lowest wages among the top 15, grew only 7%, from $457 to $489. On the other hand, wages in Professional and Technical Services grew 28%, from $2,163 to $2,774, and wages in Financial Investment and Related Activity, already the highest among the top 15, grew the fastest at 39%, from $4,520 to $6,305.</p>

--- a/app/javascript/pages/components/Calendar.jsx
+++ b/app/javascript/pages/components/Calendar.jsx
@@ -40,10 +40,14 @@ class Calendar extends React.Component {
       }
       const height = (barSize * topResults) + margin.top + margin.bottom;
 
-      const svg = d3.select('.jobs')
-        .attr('class', 'container')
+      let svg = d3.select('.jobs')
         .append('svg')
-        .attr('viewBox', [0, 0, width, height]);
+
+      if (width > 500) {
+        svg.attr('viewBox', [0, 0, width, height]);
+      } else {
+        svg.attr('viewBox', [0, 0, 700, 900]);
+      }
 
       const categories = new Set(filteredData.map((d) => d.category));
 
@@ -177,12 +181,6 @@ class Calendar extends React.Component {
         const now = d3.select('.jobs__subtitle')
           .append('div')
           .attr('class', 'jobs__year')
-          .style('font', `bold ${barSize}px var(--sans-serif)`)
-          .style('font-variant-numeric', 'tabular-nums')
-          .attr('text-anchor', 'end')
-          .attr('x', width - 6)
-          .attr('y', margin.top + barSize * (topResults - 0.45))
-          .attr('dy', '0.32em')
           .text(formatDate(allKeyframes[0][0]));
 
         d3.select('.jobs__subtitle')
@@ -197,10 +195,7 @@ class Calendar extends React.Component {
           .on('click', () => window.open('https://datacommon.mapc.org/browser/datasets/388'));
 
         return ([date], transition) => {
-          transition.end().then(() => now.text(formatDate(date))
-            .style('font-size', '68px')
-            .attr('fill-color', '#95989A')
-            .style('font-weight', 'bold'));
+          transition.end().then(() => now.text(formatDate(date)));
         };
       }
 
@@ -261,8 +256,8 @@ class Calendar extends React.Component {
           <a href="/gallery" className="back-link">{back}</a>
           <h1 className="jobs__title">Employment by Industry</h1>
           <div className="jobs" />
-          <h2 className="jobs__subtitle" />
-          <div className="container jobs__explanation">
+          <div className="jobs__subtitle" />
+          <div className="jobs__explanation">
             <p>Metro Boston has experienced rapid economic growth over the past two decades. Although the region experienced periods of employment decline during the 2001 and 2008 national recessions, its employment today is 10% above its previous peak set in 2001. Its top three employing industries since 2001—Professional and Technical Services, Educational Services, and Food Services and Drinking Places—together grew 38% from 2001 to 2018. Healthcare and social assistance industries account for a quarter of jobs among the region’s top 15 industries in 2018, and have seen 89% job growth since 2001. Jobs in Social Assistance, such as those in individual and family services and child day care, were the fastest growing among the region’s top 15, at 116%.</p>
             <p>Average wages in the region across all industries grew 15% (in real dollars) between 2001 and 2018. Yet, looking at wages in the region’s largest individual industries, wage growth has been polarized. Average weekly wages in Social Assistance—the top growing industry among the top 15—declined 4% from an already low $662 per week to $638, in 2018 dollars. Wages in Food Services and Drinking Places, the third largest industry and that with the lowest wages among the top 15, grew only 7%, from $457 to $489. On the other hand, wages in Professional and Technical Services grew 28%, from $2,163 to $2,774, and wages in Financial Investment and Related Activity, already the highest among the top 15, grew the fastest at 39%, from $4,520 to $6,305.</p>
             <p>The region’s prosperity depends not only on job growth and the continued competitiveness of the region’s economy, but also high quality of life for all its residents. With rising housing, transportation, healthcare, and childcare costs it is becoming even more difficult for low-wage employees to achieve this quality of life. While Massachusetts has increased the minimum wage in recent years, the state‘s policies should go further to ensure stability and prosperity for its lowest income workers, such as tying the minimum wage to inflation and requiring companies to pay tipped workers at least $15 an hour. Without ensuring stable, living wages for all employees, job growth in the region amounts to little.</p>

--- a/app/javascript/styles/components/Calendar.scss
+++ b/app/javascript/styles/components/Calendar.scss
@@ -110,8 +110,9 @@
 
 .jobs {
   &__subtitle {
-    @include media(medium) {
-      margin: 1rem;
+    @include media(large) {
+      float: initial;
+      margin: initial;
     }
 
     color: $color_font-medium;

--- a/app/javascript/styles/components/Calendar.scss
+++ b/app/javascript/styles/components/Calendar.scss
@@ -109,29 +109,9 @@
 }
 
 .jobs {
-  margin-right: 5rem;
-
-  &__title {
-    display: block;
-    font-family: $font_family-primary;
-    font-weight: bolder;
-    font-size: $font_size-large;
-    padding: 1rem 0;
-  }
-
-  &__year {
-    color: $color_font-medium;
-    font-family: $font_family-primary;
-    font-size: 60px;
-    font-weight: bolder;
-    line-height: 1;
-    margin-bottom: 1.5rem;
-  }
-
   &__subtitle {
     @include media(medium) {
-      left: 0;
-      margin-top: 2rem;
+      margin: 1rem;
     }
 
     color: $color_font-medium;
@@ -139,21 +119,38 @@
     float: right;
     font-family: $font_family-primary;
     font-size: $font_size-medium;
-    font-weight: bold;
-    left: -15rem;
-    margin-top: -9rem;
-    width: 17rem;
+    margin: -10rem 0 0 0;
+    max-width: 40%;
+  }
+
+  &__year {
+    @include media(small) {
+      font-size: 3rem;
+    }
+    color: $color_font-medium;
+    font-family: $font_family-primary;
+    font-size: 3.75rem;
+  }
+
+  &__title {
+    @include media(small) {
+      font-size: $font_size-medium;
+    }
+
+    display: block;
+    font-family: $font_family-primary;
+    font-size: $font_size-large;
+    padding: 1rem 0;
   }
 
   &__subtitle-text {
-    display: block;
-    float: right;
+    @include media(small) {
+      font-size: $font_size-small;
+    }
+
     color: $color_font-medium;
     font-family: $font_family-primary;
-    font-weight: bold;
     font-size: $font_size-medium;
-    margin: .5rem 0;
-    width: 17rem;
   }
 
   &__download-link {
@@ -161,15 +158,11 @@
     cursor: pointer;
     display: block;
     font-family: $font_family-primary;
-    font-style: italic;
     font-weight: 100;
-    margin-top: 1rem;
     text-decoration: underline;
   }
 
   &__explanation {
-    display: block;
-    margin-top: 3rem;
   }
 }
 

--- a/app/javascript/styles/partials/_base.scss
+++ b/app/javascript/styles/partials/_base.scss
@@ -1,23 +1,19 @@
 body {
-  color: $color_font-dark;
-  font-size: $font_size-base;
-  font-family: $font_family-primary;
-  line-height: 1.4285em;
-
   background: $color_bg-light;
+  color: $color_font-dark;
+  font-family: $font_family-primary;
+  font-size: $font_size-base;
 
   & > .ember-view,
   #root > .component.App {
     display: flex;
     flex-direction: column;
-
     min-height: 100vh;
   }
 }
 
 main {
   flex: 1 1 auto;
-
   padding-bottom: 50px;
 }
 
@@ -48,9 +44,8 @@ p {
 
 
 .divider-column {
-  position: relative;
-
   padding: 0 !important;
+  position: relative;
 }
 
 .scroll-horizontal-rotated {


### PR DESCRIPTION
Resolves # .

# Why is this change necessary?
The bar chart was not working well on mobile devices.

# How does it address the issue?
This makes it scale the bar chart race at mobile sizes.

# What side effects does it have?
Some frustrating CSS was evicted or modified to make the updates to the chart subtitle easier. A quick check of the rest of the site didn't seem to indicate that the rules had impact on it, but its possible something somewhere is a little bit different due to them. If the impact is not material I'd recommend making separate issues for those as we continue to refactor this to follow BEM conventions.
