### PR TITLE
Update bitly link and legend height

### DIFF
--- a/app/javascript/pages/components/calendar-visualizations/2020/February.jsx
+++ b/app/javascript/pages/components/calendar-visualizations/2020/February.jsx
@@ -11,7 +11,7 @@ const February = () => (
     <p>Meanwhile, in the mostly urban neighborhoods with a small share of family-sized units, families with children face stiff competition for what little is available: roommate groups with multiple incomes often outbid families. And prices for smaller places are such that members of those roommate groups can’t afford to live on their own.</p>
     <p>MAPC’s new study, <em><a href="https://metrocommon.mapc.org/reports/10">Crowded In and Priced Out: Why it’s so Hard to Find a Family-Sized Unit in Greater Boston</a></em> found that in Boston and a dozen surrounding cities and towns, households with children only occupy 39 percent of larger units. Instead, families squeeze into smaller places, two or more to a bedroom.</p>
     <p>Construction of new family-sized units is necessary, but not sufficient. We also need more smaller, senior-friendly units into which older residents can downsize. We need more one-bedroom apartments in which roommates can live affordably on their own. With a greater number and variety of units on the market, more of our region’s residents will be able to find the homes they need and can afford.</p>
-    <p>Read the full report at <a href="https://metrocommon.mapc.org/reports/10">mapc.ma/familyunits.</a></p>
+    <p>Read the full report at <a href="https://metrocommon.mapc.org/reports/10">mapc.ma/largeunits.</a></p>
   </>
 );
 

--- a/app/javascript/styles/components/Calendar.scss
+++ b/app/javascript/styles/components/Calendar.scss
@@ -133,7 +133,7 @@
   }
 
   &__iframe {
-    $mobile-legend-height: 150px;
+    $mobile-legend-height: 195px;
     @include media(medium) {
       display: block;
       float: unset;


### PR DESCRIPTION
* We needed to update the legend of the map with study area boundary to include boundary key. This changed the height of the legend. In order to keep consistent breakpoints throughout, we needed to adjust the heights of both legends.

# Why is this change necessary?
We needed to increase the size of the legend to accommodate another legend item on the Map With Boundary version that appears on DataCommon. Because both that map and the map here rely on the same media queries in the Large Units repo, this legend needed to be updated correspondingly. Additionally, we needed to update link text to correspond with the correct bitly.

# How does it address the issue?
Increase height variable to use in media queries

# What side effects does it have?
None; the variable is referenced in a couple of media queries to move the position of the legend. As for the link update, the anchor tag hasn't changed---just the displayed text.
