### PR TITLE
Att/270 sliced header

### DIFF
--- a/app/javascript/pages/components/partials/Particles.jsx
+++ b/app/javascript/pages/components/partials/Particles.jsx
@@ -30,11 +30,11 @@ class Particles extends React.Component {
     this.moveDot = this.moveDot.bind(this);
     this.drawNearestNeighborLines = this.drawNearestNeighborLines.bind(this);
     this.createDots = this.createDots.bind(this);
+    this.drawTriangle = this.drawTriangle.bind(this);
   }
 
   componentDidMount() {
     const { width, height } = this.state;
-
     window.addEventListener('resize', this.updateDimensions);
     if (width !== window.innerWidth
       || height !== this.canvas.parentNode.offsetHeight) {
@@ -92,13 +92,7 @@ class Particles extends React.Component {
       contxt.fill();
     });
     this.drawNearestNeighborLines();
-    contxt.fillStyle = 'rgba(255,255,255,1)';
-    contxt.beginPath();
-    contxt.moveTo(0, height);
-    contxt.lineTo(width, height * 0.75);
-    contxt.lineTo(width, height);
-    contxt.closePath();
-    contxt.fill();
+    this.drawTriangle();
   }
 
   moveDot(dot) {
@@ -141,6 +135,27 @@ class Particles extends React.Component {
     }
   }
 
+  drawTriangle() {
+    const { width, height } = this.state;
+    const contxt = this.canvas.getContext('2d');
+    let triangleHeight = height - 240;
+
+    if (width <= 670) {
+      triangleHeight = height;
+    } else if (width <= 960) {
+      triangleHeight = height - 140;
+    } else if (width <= 1200) {
+      triangleHeight = height - 240;
+    }
+    contxt.fillStyle = 'rgba(255,255,255,1)';
+    contxt.beginPath();
+    contxt.moveTo(0, height);
+    contxt.lineTo(width, triangleHeight);
+    contxt.lineTo(width, height);
+    contxt.closePath();
+    contxt.fill();
+  }
+
   updateDimensions() {
     this.setState({ width: window.innerWidth });
   }
@@ -150,7 +165,6 @@ class Particles extends React.Component {
     return (
       <canvas
         ref={(el) => this.canvas = el}
-        // ref="canvas"
         width={width}
         height={height}
         className="component Particles"

--- a/app/javascript/pages/components/partials/Particles.jsx
+++ b/app/javascript/pages/components/partials/Particles.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import hexToRgb from './../../utils/hexToRgb';
+import colors from './../../constants/colors'
 
 class Particles extends React.Component {
   constructor(props) {
@@ -58,11 +60,11 @@ class Particles extends React.Component {
         const y = Math.random() * prevState.height;
         prevState.dotArray.push({
           i,
-          rad: 4,
+          rad: 5,
           x,
           y,
           iteration: Math.round(Math.random() * 150) + 2000,
-          color: 'rgba(111, 198, 142, .6)',
+          color: `rgba(${hexToRgb(colors.BRAND.PRIMARY)}, .6)`,
           totalIterations: Math.round(Math.random() * 300) + 400,
           curSpot: {
             x,
@@ -126,7 +128,7 @@ class Particles extends React.Component {
             contxt.moveTo(dot1.x, dot1.y);
             contxt.lineTo(dot2.x, dot2.y);
             contxt.lineWidth = 2;
-            contxt.strokeStyle = 'rgba(68, 173, 137, .3)';
+            contxt.strokeStyle = `rgba(${hexToRgb(colors.BRAND.SECONDARY)}, .1)`;
             contxt.stroke();
             contxt.closePath();
           }
@@ -147,6 +149,11 @@ class Particles extends React.Component {
     } else if (width <= 1200) {
       triangleHeight = height - 240;
     }
+    contxt.fillStyle = 'rgba(255,255,255,.1)';
+    contxt.beginPath();
+    contxt.rect(0, 0, width, height);
+    contxt.fill();
+
     contxt.fillStyle = 'rgba(255,255,255,1)';
     contxt.beginPath();
     contxt.moveTo(0, height);

--- a/app/javascript/pages/components/partials/Particles.jsx
+++ b/app/javascript/pages/components/partials/Particles.jsx
@@ -25,8 +25,10 @@ class Particles extends React.Component {
       dotCount = 200,
       lineWidth = 2,
       neigborDistance = 45,
-      dotColor = colors.BRAND.PRIMARY,
-      lineColor = `rgba(${hexToRgb(colors.BRAND.SECONDARY)}, .3)`,
+      // dotColor = colors.BRAND.PRIMARY,
+      // lineColor = `rgba(${hexToRgb(colors.BRAND.SECONDARY)}, .3)`,
+      dotColor = 'rgba(111, 198, 142, .6)',
+      lineColor = 'rgba(68, 173, 137, .3)',
       w = window.innerWidth,
       h = this.canvas.parentNode.offsetHeight,
       dotArray = [];
@@ -128,6 +130,13 @@ class Particles extends React.Component {
           }
         }
       }
+      contxt.fillStyle = 'rgba(255,255,255,1)'
+      contxt.beginPath()
+      contxt.moveTo(0, h);
+      contxt.lineTo(w, h * .75);
+      contxt.lineTo(w, h);
+      contxt.closePath();
+      contxt.fill();
     }
 
     function checkDist(itemA, itemB) {
@@ -190,6 +199,7 @@ class Particles extends React.Component {
 
   render() {
     const { width, height } = this.state;
+    console.log(window)
 
     return (
       <canvas

--- a/app/javascript/styles/components/Particles.scss
+++ b/app/javascript/styles/components/Particles.scss
@@ -1,12 +1,7 @@
-.component.Particles {
-
+.Particles {
+  height: 100%;
+  left: 0;
+  max-width: 100%;
   position: absolute;
   top: 0;
-  left: 0;
-
-  height: 100%;
-  max-width: 100%;
-
-  opacity: .6;
-
 }

--- a/app/javascript/styles/routes/Home.scss
+++ b/app/javascript/styles/routes/Home.scss
@@ -1,7 +1,7 @@
 .route.Home {
 
   .page-header {
-    padding: 120px 0;
+    padding: 120px 0 240px;
 
     text-align: center;
 


### PR DESCRIPTION
Resolves #270 .

# Why is this change necessary?
- As part of the homepage edits, the particle backdrop needed rewiring to allow for a resizable triangle to be painted on top (creating an asymmetric appearance).

# How does it address the issue?
- Refactor existing particles code to move functions outside of `componentDidMount` (making it easier to add an event listener for screen resizing)
- Add and re-draw the triangle on each interval so that it always stays on top of the particles
- Add breakpoints to remove the triangle on smaller screen sizes

# What side effects does it have?
None so far, but it's important to note that the current CSS breakpoints are temporary; we'll have a better understanding of the size/angle breakdown after we add the mini-calendar component and see how much screen space it takes up.