### PR TITLE
Att/tooltip zindex

### DIFF
--- a/app/javascript/pages/components/gallery/2020/April.jsx
+++ b/app/javascript/pages/components/gallery/2020/April.jsx
@@ -107,12 +107,13 @@ const April = () => {
         const tractId = clickedData[0].properties.ct10_id;
         const tractData = percentageCompOwnership[tractId] <= 100
           ? `${d3.format('.1f')(percentageCompOwnership[tractId])}% (&#177; ${compMarginOfError[tractId]}%) of approx. ${d3.format(',')(numHouseholds[tractId])} households`
-          : 'Data unavailable';
+          : 'Computer ownership data unavailable';
+        const returnRate = +responseRates[tractId] !== 99999.0 ? `${responseRates[tractId]}% 2010 census return rate` : '2010 census return rate unavailable'
         const tooltipText = `<p class='tooltip__title'>Tract ${tractId}
         (${clickedData[2].properties.municipal})</p>
         <ul class='tooltip__list'>
         <li class='tooltip__text'>${tractData}</li>
-        <li class='tooltip__text'>${responseRates[tractId]}% 2010 census return rate</li>
+        <li class='tooltip__text'>${returnRate}</li>
         </ul>`;
         new mapboxgl.Popup()
           .setLngLat(e.lngLat)

--- a/app/javascript/styles/components/Calendar.scss
+++ b/app/javascript/styles/components/Calendar.scss
@@ -134,7 +134,12 @@
       float: unset;
       width: 100%;
     }
+    border: 0;
     float: left;
+    height: 500px;
+    margin: 0 32px 32px 0;
+    width: 700px;
+    z-index: 10;
   }
   
   &__subtitle {

--- a/app/javascript/styles/components/visualizations/MapboxGL.scss
+++ b/app/javascript/styles/components/visualizations/MapboxGL.scss
@@ -1,23 +1,18 @@
-$mapHeight: calc(94vw * 500 / 700);
-
 .mapboxgl {
   &__container {
     @include media(medium) {
       display: block;
       float: unset;
-      height: $mapHeight;
+      height: calc(94vw * 500 / 700);
       margin: 0 auto;
       max-height: 500px;
       max-width: 700px;
       width: 100%;
     }
-    border: 0;
-    float: left;
     height: 500px;
-    margin: 0 32px 32px 0;
     width: 700px;
-    z-index: 10;
   }
+
   &__tooltip {
     background: #fff;
     border: 0;

--- a/spec/system/calendar_spec.rb
+++ b/spec/system/calendar_spec.rb
@@ -22,4 +22,9 @@ RSpec.describe "calendar", :type => :system do
     visit "/calendar/2020/march"
     expect(page).to have_css('.d3-map__points', visible: false)
   end
+
+  it "displays a map for April", js: true do
+    visit "/calendar/2020/april"
+    expect(page).to have_css('.mapboxgl-canvas')
+  end
 end


### PR DESCRIPTION
# Why is this change necessary?
- Census tracts with no data available for return rate were listed as having a return rate of 99999%
- Map tooltip was layering underneath the legend (instead of floating on top) in instances where the two collided
# How does it address the issue?
- Filter out return rates of 9999% and instead displays "data not available" message on tooltip
- Move some map position styling into the wrapper class to match the correct layering as seen in the February map (iframe of external Github Pages site)
- (Semi-unrelated) Add quick test making sure that mapboxgl loads in April map
# What side effects does it have?
Moving the positioning styling into `calendar-viz__wrapper` impacts both March and April maps; it doesn't look like it negatively impacts March, but is worth keeping in mind.