### PR TITLE
Replace March API call with static spreadsheet

### DIFF
--- a/app/assets/data/march2020.csv
+++ b/app/assets/data/march2020.csv
@@ -1,0 +1,2167 @@
+name,status,year_compl,hu,commsf,latitude,longitude,municipal,rpa_name
+Marion Woods,cancelled,2015,9,0,42.38031172,-71.51369078,Hudson,Metropolitan Area Planning Council
+King David Hotel,cancelled,2015,0,0,42.26621311,-71.17001848,Boston,Metropolitan Area Planning Council
+3 pond park,completed,2015,0,5000,42.17586973,-70.91876792,Hingham,Metropolitan Area Planning Council
+Neponset Field,completed,2015,95,0,42.26158234,-71.10632078,Boston,Metropolitan Area Planning Council
+"5 Channel Center - Fraunhofer ""Living Lab""",completed,2015,0,50000,42.3449167,-71.05173498,Boston,Metropolitan Area Planning Council
+40 Washington St,completed,2015,0,7000,42.44112336,-71.07210669,Melrose,Metropolitan Area Planning Council
+Ink Block- 300 Harrison Avenue,completed,2015,471,85000,42.34603207,-71.06246155,Boston,Metropolitan Area Planning Council
+Starboard Place (Parcel 39A),completed,2015,54,50790,42.37607848,-71.05333727,Boston,Metropolitan Area Planning Council
+The Viridian (1282 Boylston),completed,2015,322,15000,42.34465097,-71.09694034,Boston,Metropolitan Area Planning Council
+Middlesex School Paine Barn,completed,2015,0,8050,42.49848927,-71.36794229,Concord,Metropolitan Area Planning Council
+FM Global Campus Office Development Norwood,completed,2015,0,14025,42.17401652,-71.19070573,Norwood,Metropolitan Area Planning Council
+Madison Tropical Parcel 10 (Tropical Foods),completed,2015,30,94000,42.33323687,-71.0823477,Boston,Metropolitan Area Planning Council
+15 Zaloga Way,completed,2015,1,0,42.60774033,-71.01395906,Middleton,Metropolitan Area Planning Council
+401 West First Street,completed,2015,45,0,42.33771333,-71.04437537,Boston,Metropolitan Area Planning Council
+637 East First Street,completed,2015,23,0,42.33807901,-71.03403333,Boston,Metropolitan Area Planning Council
+Hyde-Blakemore Project,completed,2015,13,0,42.28496133,-71.11920494,Boston,Metropolitan Area Planning Council
+West Square,completed,2015,255,0,42.34095129,-71.04975324,Boston,Metropolitan Area Planning Council
+Brigham and Womens Hospital - Green Project,completed,2015,0,0,42.33510811,-71.10451949,Boston,Metropolitan Area Planning Council
+Boston Public Market at 136 Blackstone Street,completed,2015,0,29460,42.36216866,-71.05749063,Boston,Metropolitan Area Planning Council
+Gate of Heaven Residential Development,completed,2015,24,0,42.33448472,-71.04030731,Boston,Metropolitan Area Planning Council
+Amberfields Subdivision,completed,2015,30,0,42.02297391,-71.37300119,Wrentham,Metropolitan Area Planning Council
+Boston Childrens Museum Expansion & Renovation,completed,2015,0,22300,42.35195696,-71.04975608,Boston,Metropolitan Area Planning Council
+174 Hampden Street,completed,2015,0,25000,42.32721946,-71.07495655,Boston,Metropolitan Area Planning Council
+Greater Boston Food Bank,completed,2015,0,110000,42.33422851,-71.06566063,Boston,Metropolitan Area Planning Council
+Warren Green,completed,2015,17,0,42.37400672,-71.06152572,Boston,Metropolitan Area Planning Council
+75 Brainerd Road,completed,2015,104,0,42.34765346,-71.13412665,Boston,Metropolitan Area Planning Council
+1000 Washington Street,completed,2015,0,100000,42.34602963,-71.06409146,Boston,Metropolitan Area Planning Council
+"Period Realty Trust, 68-86 Thoreau St.",completed,2015,0,100,42.45660042,-71.35743461,Concord,Metropolitan Area Planning Council
+Mass Bio Lab Phase II,completed,2015,0,97000,42.28577026,-71.10286053,Boston,Metropolitan Area Planning Council
+Spaulding Rehabilitation CNY,completed,2015,0,240000,42.3786573,-71.04896329,Boston,Metropolitan Area Planning Council
+Olmsted Green Lena Park CDC and Brooke Charter School,completed,2015,0,49000,42.29458484,-71.09224632,Boston,Metropolitan Area Planning Council
+Woodland Meadows,completed,2015,16,,42.29284228,-71.50482646,Southborough,Metropolitan Area Planning Council
+YMCA Renovation,completed,2015,0,62390,42.33909927,-71.08822089,Boston,Metropolitan Area Planning Council
+Cowings Cove,completed,2015,7,,42.18959248,-70.80212147,Norwell,Metropolitan Area Planning Council
+362 Elm Street,completed,2015,0,70000,42.34664766,-71.57369437,Marlborough,Metropolitan Area Planning Council
+100 Arlington,completed,2015,128,10250,42.34991308,-71.06945115,Boston,Metropolitan Area Planning Council
+33 Central,completed,2015,8,1000,42.46408057,-70.9445009,Lynn,Metropolitan Area Planning Council
+24-30 Rockland Street,completed,2015,40,0,42.32195912,-71.08402505,Boston,Metropolitan Area Planning Council
+368 Congress Street,completed,2015,0,100451,42.35035618,-71.04776823,Boston,Metropolitan Area Planning Council
+Hilton Homewood Suites,completed,2015,0,42500,42.33133843,-71.12063853,Brookline,Metropolitan Area Planning Council
+Sophia Snow House,completed,2015,102,0,42.29836952,-71.13072957,Boston,Metropolitan Area Planning Council
+Roxbury Senior Building- 28 Gurney Street,completed,2015,40,0,42.32920965,-71.09687542,Boston,Metropolitan Area Planning Council
+Paradigm at Blakemore Project,completed,2015,16,0,42.28596662,-71.11997608,Boston,Metropolitan Area Planning Council
+Minute Man ARC,completed,2015,0,29822,42.44167941,-71.4243385,Concord,Metropolitan Area Planning Council
+Windsor Estates,completed,2015,44,0,42.51156663,-71.01510218,Lynnfield,Metropolitan Area Planning Council
+Massachusetts General Hospital - Museum and History Center,completed,2015,0,8000,42.36049807,-71.06856181,Boston,Metropolitan Area Planning Council
+296 Cambridge Street,completed,2015,0,1400,42.36092794,-71.06847722,Boston,Metropolitan Area Planning Council
+65 Beacon St,completed,2015,14,4000,42.37642917,-71.10366817,Somerville,Metropolitan Area Planning Council
+648 Old West Central Street - Commercial Development,completed,2015,0,8955,42.09095028,-71.42431398,Franklin,Metropolitan Area Planning Council
+Mt. Skirgo ridge,completed,2015,30,0,42.09856624,-70.73491777,Marshfield,Metropolitan Area Planning Council
+Highland Estates,completed,2015,14,0,42.22984329,-70.79802839,Cohasset,Metropolitan Area Planning Council
+The Village at Cedarcrest,completed,2015,9,0,42.18213128,-71.15364577,Canton,Metropolitan Area Planning Council
+South end Farms,completed,2015,52,0,42.19036926,-71.35617293,Millis,Metropolitan Area Planning Council
+Lavender Lane,completed,2015,4,0,42.48073386,-71.30922272,Bedford,Metropolitan Area Planning Council
+VA housing,completed,2015,70,0,42.50381402,-71.2709775,Bedford,Metropolitan Area Planning Council
+114 Mt. Auburn St (Conductors Building),completed,2015,0,83200,42.37297576,-71.12247865,Cambridge,Metropolitan Area Planning Council
+E. L. Harvey & Sons,completed,2015,0,125300,42.25322801,-71.58625727,Hopkinton,Metropolitan Area Planning Council
+563-603 Concord Ave,completed,2015,61,7184,42.38929093,-71.14443763,Cambridge,Metropolitan Area Planning Council
+74 Highland Street,completed,2015,7,0,42.3280158,-71.0922041,Boston,Metropolitan Area Planning Council
+Palmer Street,completed,2015,0,26000,42.33033955,-71.08278241,Boston,Metropolitan Area Planning Council
+375 Market Street,completed,2015,39,0,42.35065245,-71.15327923,Boston,Metropolitan Area Planning Council
+Gallery Automotive,completed,2015,0,68500,42.16657631,-70.89922332,Rockland,Metropolitan Area Planning Council
+86 Dummer Street,completed,2015,32,0,42.34956724,-71.11507427,Brookline,Metropolitan Area Planning Council
+16 Tower Street,completed,2015,4,0,42.30035172,-71.44503799,Framingham,Metropolitan Area Planning Council
+Christa Mcauliffe Library - 746 Water Street,completed,2015,0,17000,42.32881926,-71.43277167,Framingham,Metropolitan Area Planning Council
+198 Union Avenue,completed,2015,6,0,42.28264326,-71.42099992,Framingham,Metropolitan Area Planning Council
+Mass College of Art Residence Hall,completed,2015,145,0,42.33586064,-71.09963501,Boston,Metropolitan Area Planning Council
+St. Kevin's Redevelopment,completed,2015,80,0,42.31564686,-71.0669799,Boston,Metropolitan Area Planning Council
+The Coolidge at Sudbury,completed,2015,64,0,42.36085074,-71.40105504,Sudbury,Metropolitan Area Planning Council
+BC High School Cadigan Hall Project,completed,2015,0,28000,42.3160914,-71.04495782,Boston,Metropolitan Area Planning Council
+307 Dorchester Avenue/FW Webb,completed,2015,0,45000,42.33731983,-71.05792877,Boston,Metropolitan Area Planning Council
+23-25 and 33-35 Grantley St Condominium Project,completed,2015,16,0,42.24923883,-71.12532525,Boston,Metropolitan Area Planning Council
+45 Stuart Street,completed,2015,404,0,42.35141894,-71.06393761,Boston,Metropolitan Area Planning Council
+Russo Estates,completed,2015,6,0,42.48591426,-71.13458439,Woburn,Metropolitan Area Planning Council
+316-322 Summer Street,completed,2015,0,135600,42.3497282,-71.04857321,Boston,Metropolitan Area Planning Council
+Kasanof Bakery - 233 Blue Hill Ave,completed,2015,71,3500,42.31708545,-71.07882652,Boston,Metropolitan Area Planning Council
+1 Village Terrace,completed,2015,5,0,42.38061618,-71.10477102,Somerville,Metropolitan Area Planning Council
+Central Boston Elder Services,completed,2015,57,0,42.33037458,-71.08444748,Boston,Metropolitan Area Planning Council
+Grand view Estates,completed,2015,40,0,42.50903101,-71.02193419,Lynnfield,Metropolitan Area Planning Council
+Manor Way Circle Subdivision,completed,2015,3,0,42.22919508,-70.80349218,Cohasset,Metropolitan Area Planning Council
+Hillcrest Estates,completed,2015,68,0,42.25401613,-71.49332109,Ashland,Metropolitan Area Planning Council
+Riverdale Place,completed,2015,14,0,42.63198129,-70.67457054,Gloucester,Metropolitan Area Planning Council
+59 Bonair St,completed,2015,1,,42.38884417,-71.09004921,Somerville,Metropolitan Area Planning Council
+JPNDC J5 Building K- 31 Germania Street,completed,2015,35,0,42.31462595,-71.10325321,Boston,Metropolitan Area Planning Council
+41-43 Saratoga Street,completed,2015,18,0,42.37600747,-71.03747896,Boston,Metropolitan Area Planning Council
+Benchmark Senior Living,completed,2015,87,0,42.493905,-71.12489844,Woburn,Metropolitan Area Planning Council
+157 Hancock Street,completed,2015,14,0,42.27947912,-71.0334996,Quincy,Metropolitan Area Planning Council
+Ingrid Lane,completed,2015,2,0,42.21901747,-70.75226434,Scituate,Metropolitan Area Planning Council
+525 Beach Street Affordable Housing,completed,2015,30,0,42.40952148,-70.99835592,Revere,Metropolitan Area Planning Council
+Boston University - East Campus Student Service Center,completed,2015,0,36000,42.34988884,-71.09835126,Boston,Metropolitan Area Planning Council
+Badus Brook Subdivision,completed,2015,8,0,42.05600186,-71.33609689,Wrentham,Metropolitan Area Planning Council
+2 Washington Street,completed,2015,94,2200,42.44012356,-71.07247627,Melrose,Metropolitan Area Planning Council
+Mission on the Bay,completed,2015,0,6282,42.46782849,-70.91715262,Swampscott,Metropolitan Area Planning Council
+Trinity Episcopal Church Expansion,completed,2015,0,19105,42.45866254,-71.36455997,Concord,Metropolitan Area Planning Council
+150 Green Street,completed,2015,6,0,42.46542733,-71.05938299,Melrose,Metropolitan Area Planning Council
+South Shore Medical Center,completed,2015,0,45760,42.15782937,-70.87725882,Norwell,Metropolitan Area Planning Council
+188 Lawrence Street,completed,2015,0,17041,42.28085405,-71.40541946,Framingham,Metropolitan Area Planning Council
+192 Raymond St,completed,2015,8,0,42.38797889,-71.12760889,Cambridge,Metropolitan Area Planning Council
+191 Beal St,completed,2015,0,5500,42.24611849,-70.92099536,Hingham,Metropolitan Area Planning Council
+Harrison Commons - Former BC high,completed,2015,136,0,42.33669294,-71.07226127,Boston,Metropolitan Area Planning Council
+Deutsches Altenheim Addition,completed,2015,62,0,42.27346613,-71.15907832,Boston,Metropolitan Area Planning Council
+Heritage Development Capital Improvements,completed,2015,0,0,42.36877245,-71.03896063,Boston,Metropolitan Area Planning Council
+Christa Mcauliffe Charter School - 139 Newbury Street,completed,2015,0,32834,42.30773823,-71.395001,Framingham,Metropolitan Area Planning Council
+Dana Farber Cancer Institute,completed,2015,0,275000,42.33758802,-71.10809298,Boston,Metropolitan Area Planning Council
+Inwood West Apartments,completed,2015,34,0,42.52783708,-71.13468905,Woburn,Metropolitan Area Planning Council
+Kroc Community Center,completed,2015,0,95000,42.31977265,-71.06936409,Boston,Metropolitan Area Planning Council
+The Cohasset Village Town Homes,completed,2015,11,0,42.24012889,-70.80360084,Cohasset,Metropolitan Area Planning Council
+Russia Wharf,completed,2015,50,660000,42.35320621,-71.05251018,Boston,Metropolitan Area Planning Council
+Pudding Hill,completed,2015,66,0,42.09082494,-70.71588611,Marshfield,Metropolitan Area Planning Council
+0 Paul Street,completed,2015,1,0,42.2986336,-71.44882405,Framingham,Metropolitan Area Planning Council
+R-Way Farm,completed,2015,6,0,42.64792085,-70.81247454,Essex,Metropolitan Area Planning Council
+18 Robert Street,completed,2015,14,0,42.28718426,-71.13232652,Boston,Metropolitan Area Planning Council
+150 Chestnut Hill Ave,completed,2015,21,0,42.34189073,-71.15353094,Boston,Metropolitan Area Planning Council
+"The Levedo Building, 241 Talbot Avenue",completed,2015,24,0,42.29141063,-71.07667282,Boston,Metropolitan Area Planning Council
+687-697 Masschusetts Avenue,completed,2015,30,0,42.33519891,-71.07581604,Boston,Metropolitan Area Planning Council
+Blessed Sacrament Campus Redevelopment,completed,2015,81,0,42.32307341,-71.10759988,Boston,Metropolitan Area Planning Council
+Winter Hollow,completed,2015,7,,42.2670598,-71.47734043,Ashland,Metropolitan Area Planning Council
+The Estates at Walpole,completed,2015,196,0,42.16501206,-71.22483051,Walpole,Metropolitan Area Planning Council
+Fenway Triangle Mixed Use Project,completed,2015,290,450000,42.3445221,-71.09911268,Boston,Metropolitan Area Planning Council
+160-180 Cambridgepark Dr,completed,2015,398,0,42.39447941,-71.14764039,Cambridge,Metropolitan Area Planning Council
+Isabella Stewart Gardner Museum,completed,2015,0,50000,42.33849409,-71.09886764,Boston,Metropolitan Area Planning Council
+41 Westland Avenue,completed,2015,48,0,42.344002,-71.08780301,Boston,Metropolitan Area Planning Council
+881-883 East Second Street,completed,2015,16,0,42.33720665,-71.02782903,Boston,Metropolitan Area Planning Council
+1797-1801 Massachusetts Ave (Art Institute),completed,2015,0,74500,42.38642405,-71.11870686,Cambridge,Metropolitan Area Planning Council
+44-48 Grove Street,completed,2015,0,5200,42.45322639,-71.06682424,Melrose,Metropolitan Area Planning Council
+39/47 Fayette Street,completed,2015,24,0,42.26002602,-71.00418928,Quincy,Metropolitan Area Planning Council
+Residences at Constitution Drive,completed,2015,5,0,42.49168401,-71.44952631,Acton,Metropolitan Area Planning Council
+Lexus of Hingham,completed,2015,0,60000,42.18116767,-70.9112993,Hingham,Metropolitan Area Planning Council
+Wincrest Definitive Subdivision,completed,2015,47,0,42.49726854,-71.08915804,Stoneham,Metropolitan Area Planning Council
+North Shore Business Center,completed,2015,0,77000,42.57761714,-70.99524439,Middleton,Metropolitan Area Planning Council
+148 Dorchester Avenue,completed,2015,52,0,42.34172108,-71.05672904,Boston,Metropolitan Area Planning Council
+Hotel Commonwealth Expansion,completed,2015,0,134000,42.34848811,-71.09565114,Boston,Metropolitan Area Planning Council
+95 Eames Street,completed,2015,0,9800,42.26930322,-71.41460647,Framingham,Metropolitan Area Planning Council
+Gracie Lane Subdivision,completed,2015,6,0,42.48122924,-70.91107719,Swampscott,Metropolitan Area Planning Council
+New Intermodal Center at Hingham Shipyard,completed,2015,0,8400,42.2530892,-70.91933877,Hingham,Metropolitan Area Planning Council
+22 Water St (Mac-Grey),completed,2015,392,0,42.3729928,-71.07875742,Cambridge,Metropolitan Area Planning Council
+Middlewood ,completed,2015,20,0,42.59279323,-70.92685962,Wenham,Metropolitan Area Planning Council
+WAVE project,completed,2015,0,33000,42.47625779,-71.47193292,Acton,Metropolitan Area Planning Council
+159 First Street,completed,2015,115,3800,42.36624241,-71.07850063,Cambridge,Metropolitan Area Planning Council
+417 South Street,completed,2015,0,145000,42.33297898,-71.54481998,Marlborough,Metropolitan Area Planning Council
+Almquist Subdivision,completed,2015,8,,42.23239827,-70.99823521,Braintree,Metropolitan Area Planning Council
+450 Kendall St (CRP),completed,2015,0,53000,42.36336418,-71.0815177,Cambridge,Metropolitan Area Planning Council
+Lexington Way,completed,2015,7,0,42.14584639,-71.18487061,Sharon,Metropolitan Area Planning Council
+17 Morley Street,completed,2015,2,0,42.32921883,-71.09203171,Boston,Metropolitan Area Planning Council
+47 Thorndike Street,completed,2015,0,2630,42.33297945,-71.07865254,Boston,Metropolitan Area Planning Council
+828 West Central Street,completed,2015,0,3000,42.08965836,-71.43568799,Franklin,Metropolitan Area Planning Council
+CVS Pharmacy,completed,2015,0,10000,42.47403311,-71.45047945,Acton,Metropolitan Area Planning Council
+Kerrigan Way,completed,2015,7,0,42.4884426,-71.12205637,Woburn,Metropolitan Area Planning Council
+Woods Hill Table Restaurant,completed,2015,0,5200,42.45666859,-71.39309214,Concord,Metropolitan Area Planning Council
+"Veterinary Dental Services, LLC",completed,2015,0,5074,42.48077654,-71.50799691,Boxborough,Metropolitan Area Planning Council
+River Park Lofts,completed,2015,65,10394,42.36869609,-71.19511008,Watertown,Metropolitan Area Planning Council
+Residences at Dahlgren Hall at 309 E Street,completed,2015,18,0,42.33717736,-71.04954157,Boston,Metropolitan Area Planning Council
+Castle Square,completed,2015,500,0,42.34614025,-71.06797238,Boston,Metropolitan Area Planning Council
+Old Colony Phase II,completed,2015,170,0,42.32998296,-71.05187776,Boston,Metropolitan Area Planning Council
+381 Congress Street,completed,2015,44,0,42.34956048,-71.04764,Boston,Metropolitan Area Planning Council
+West Broadway Redevelopment,completed,2015,133,0,42.34118824,-71.04859362,Boston,Metropolitan Area Planning Council
+Roslindale Commons Condominium,completed,2015,12,5000,42.28848909,-71.12632092,Boston,Metropolitan Area Planning Council
+90 Smith Street - Basilica Court Renovations,completed,2015,0,38852,42.33374444,-71.09996748,Boston,Metropolitan Area Planning Council
+100 Fellsway Wst,completed,2015,19,0,42.39355942,-71.08725467,Somerville,Metropolitan Area Planning Council
+The Victor,completed,2015,284,14910,42.36528348,-71.05980665,Boston,Metropolitan Area Planning Council
+Church Street Commons,completed,2015,8,4320,42.54718399,-71.17238034,Wilmington,Metropolitan Area Planning Council
+Blandino Farms,completed,2015,16,,42.28856212,-71.05619571,Boston,Metropolitan Area Planning Council
+Congregacion Leon de Juda Sanctuary,completed,2015,0,20654,42.33442612,-71.07664507,Boston,Metropolitan Area Planning Council
+Hingham Municipal Light Plant,completed,2015,0,24000,42.23476231,-70.91778839,Hingham,Metropolitan Area Planning Council
+Oliver Lofts (Terrace Street Lofts),completed,2015,175,0,42.32698092,-71.09847176,Boston,Metropolitan Area Planning Council
+Nu Life Development,completed,2015,16,3095,42.31101033,-71.08106378,Boston,Metropolitan Area Planning Council
+1486 Tremont Street,completed,2015,66,6200,42.33176792,-71.09884951,Boston,Metropolitan Area Planning Council
+The Durant Wellesley (change to Belclare Wellesley),completed,2015,25,8000,42.29542258,-71.2927335,Wellesley,Metropolitan Area Planning Council
+12 Old Forest Street,completed,2015,1,0,42.59245871,-71.03126344,Middleton,Metropolitan Area Planning Council
+Ipswich River Townhouses,completed,2015,14,0,42.57122013,-71.08195431,North Reading,Metropolitan Area Planning Council
+Highland Farms,completed,2015,5,0,42.54539075,-71.4777537,Littleton,Metropolitan Area Planning Council
+Sage Hill,completed,2015,7,0,42.37068219,-71.36285674,Wayland,Metropolitan Area Planning Council
+White Oak Farm,completed,2015,13,0,42.12196237,-70.70263071,Marshfield,Metropolitan Area Planning Council
+Annisquam Woods,completed,2015,6,0,42.6582374,-70.66014225,Gloucester,Metropolitan Area Planning Council
+25 Hamlet,completed,2015,2,,42.3837035,-71.09287886,Somerville,Metropolitan Area Planning Council
+7 Temple St (YWCA),completed,2015,40,0,42.36670778,-71.10442074,Cambridge,Metropolitan Area Planning Council
+Northridge Apartments,completed,2015,33,0,42.38215688,-71.56639347,Hudson,Metropolitan Area Planning Council
+54 Loomis Street,completed,2015,19,2860,42.48639872,-71.27581033,Bedford,Metropolitan Area Planning Council
+285 Great Road,completed,2015,0,3600,42.48663471,-71.26383879,Bedford,Metropolitan Area Planning Council
+68 Beale Street,completed,2015,22,0,42.26589999,-71.01826351,Quincy,Metropolitan Area Planning Council
+St Elizabeth's Hospital - Connel ED Urgent Care Building,completed,2015,0,46000,42.34889951,-71.14824361,Boston,Metropolitan Area Planning Council
+Studley Farm,completed,2015,9,0,42.20482913,-70.79954039,Scituate,Metropolitan Area Planning Council
+Innovation and Design Building,completed,2015,0,1400000,42.3442441,-71.03005618,Boston,Metropolitan Area Planning Council
+Milford Regional Medical Center,completed,2015,0,115000,42.13366574,-71.52703847,Milford,Metropolitan Area Planning Council
+William McKinley Elementary School,completed,2015,0,103200,42.41097404,-71.01670929,Revere,Metropolitan Area Planning Council
+Forest Green Estates,completed,2015,29,0,42.59953365,-71.08346889,North Reading,Metropolitan Area Planning Council
+Burnham Building,completed,2015,0,370000,42.35558195,-71.05969833,Boston,Metropolitan Area Planning Council
+The Gables,completed,2015,296,6777,42.36462292,-71.17391784,Watertown,Metropolitan Area Planning Council
+360 West Second Street,completed,2015,25,0,42.33822733,-71.04667631,Boston,Metropolitan Area Planning Council
+Quincy Heights,completed,2015,129,0,42.31219511,-71.07355396,Boston,Metropolitan Area Planning Council
+lido juice,completed,2015,0,1000,42.24172638,-70.88955772,Hingham,Metropolitan Area Planning Council
+Dunmore Place,completed,2015,0,0,42.32563514,-71.07474702,Boston,Metropolitan Area Planning Council
+Crosstown Center Phase II,completed,2015,0,200000,42.33297826,-71.07356952,Boston,Metropolitan Area Planning Council
+Harvard University - 28 Travis Street,completed,2015,0,80150,42.36215802,-71.12722961,Boston,Metropolitan Area Planning Council
+648-656 Saratoga Street,completed,2015,18,0,42.38245483,-71.02126726,Boston,Metropolitan Area Planning Council
+Ames Chapel Renovation,completed,2015,0,800,42.24221167,-70.88563587,Hingham,Metropolitan Area Planning Council
+Herb Chambers Volvo of Norwood,completed,2015,0,52600,42.17670127,-71.19030027,Norwood,Metropolitan Area Planning Council
+Boston Children's Hospital - Binney Street Addition,completed,2015,0,0,42.33828335,-71.10696683,Boston,Metropolitan Area Planning Council
+Channel Wharf,completed,2015,45,7000,42.33770217,-71.04437697,Boston,Metropolitan Area Planning Council
+crossroads corporate center,completed,2015,0,402000,42.30153313,-71.48418632,Framingham,Metropolitan Area Planning Council
+Winsor School:Wellness /Performance Center,completed,2015,0,110000,42.33996056,-71.10702572,Boston,Metropolitan Area Planning Council
+Endicott Ice Rink,completed,2015,0,39935,42.55711983,-70.84818347,Beverly,Metropolitan Area Planning Council
+263-265 Northampton St.,completed,2015,37,0,42.33954558,-71.08154032,Boston,Metropolitan Area Planning Council
+219 Monsignor O'Brien Highway,completed,2015,0,50368,42.37282655,-71.07956878,Cambridge,Metropolitan Area Planning Council
+AC Hotel Boston North - Station Landing,completed,2015,0,50000,42.40309025,-71.08141582,Medford,Metropolitan Area Planning Council
+The Lancaster at 1501 Commonwealth Avenue,completed,2015,55,0,42.34744867,-71.14123328,Boston,Metropolitan Area Planning Council
+Gray Farm Road,completed,2015,53,0,42.5517956,-71.50484984,Littleton,Metropolitan Area Planning Council
+Settlers Lane,completed,2015,6,0,42.61307135,-70.8894847,Wenham,Metropolitan Area Planning Council
+Emerald Block - FBI Headquartes,completed,2015,0,250000,42.39960055,-71.04039981,Chelsea,Metropolitan Area Planning Council
+Toils End/Fox Run subdivision,completed,2015,35,0,42.08477387,-71.3430478,Wrentham,Metropolitan Area Planning Council
+181 Massachusetts Ave (Novartis),completed,2015,0,572663,42.36177912,-71.09597205,Cambridge,Metropolitan Area Planning Council
+White Ash Farm,completed,2015,3,0,42.19523785,-70.75668138,Scituate,Metropolitan Area Planning Council
+Waters Edge Apartments - 1350 Worcester Road,completed,2015,300,0,42.29379201,-71.46855014,Framingham,Metropolitan Area Planning Council
+Mechanic Lofts,completed,2015,34,0,42.24677046,-70.99933172,Quincy,Metropolitan Area Planning Council
+Boston University - New Balance Field,completed,2015,0,141068,42.35318959,-71.12173493,Boston,Metropolitan Area Planning Council
+Glover Place,completed,2015,10,0,42.18992957,-71.3091762,Medfield,Metropolitan Area Planning Council
+Summer Valley Lane,completed,2015,2,0,42.14192731,-71.44352706,Medway,Metropolitan Area Planning Council
+267-269 Humphrey St,completed,2015,3,0,42.46673756,-70.91368069,Swampscott,Metropolitan Area Planning Council
+158-160 Essex St,completed,2015,3,0,42.47710586,-70.92004561,Swampscott,Metropolitan Area Planning Council
+North Reading Middle-High School,completed,2015,0,73900,42.57605059,-71.08858112,North Reading,Metropolitan Area Planning Council
+MassDOT I-93 Viaduct Parking Lots,completed,2015,0,0,42.34122248,-71.06272034,Boston,Metropolitan Area Planning Council
+Union Corners,completed,2015,6,0,42.46806249,-70.93932242,Lynn,Metropolitan Area Planning Council
+Reynolds Farm,completed,2015,12,0,42.20251811,-71.24617314,Westwood,Metropolitan Area Planning Council
+1881 Worcester Road Parking Lot Expansion,completed,2015,0,,42.29785404,-71.48576959,Framingham,Metropolitan Area Planning Council
+Christian Way,completed,2015,3,0,42.21241764,-71.58180708,Hopkinton,Metropolitan Area Planning Council
+Pleasant Plaza,completed,2015,307,30000,42.4267878,-71.06801264,Malden,Metropolitan Area Planning Council
+Crossroads Place,completed,2015,0,5700,42.12770929,-71.51853452,Milford,Metropolitan Area Planning Council
+Harvard University: Arnold Arboretum Research Building,completed,2015,0,40000,42.30064648,-71.12312279,Boston,Metropolitan Area Planning Council
+BIDMC - Bowdoin Street Health Center,completed,2015,0,4100,42.30587715,-71.06782831,Boston,Metropolitan Area Planning Council
+Stop&Shop (Hyde Park),completed,2015,0,68818,42.24252751,-71.12723985,Boston,Metropolitan Area Planning Council
+336 Humphrey St,completed,2015,2,0,42.46772452,-70.91190014,Swampscott,Metropolitan Area Planning Council
+TD Bank - 1112 Main Street,completed,2015,0,2900,42.45643718,-71.38815049,Concord,Metropolitan Area Planning Council
+Atlantic Crossing Subdivision,completed,2015,14,0,42.47288995,-70.89406638,Swampscott,Metropolitan Area Planning Council
+Hanover Vinnin Square,completed,2015,184,0,42.47919639,-70.90736351,Swampscott,Metropolitan Area Planning Council
+Norwood Acres,completed,2015,2,0,42.14892762,-71.44573369,Medway,Metropolitan Area Planning Council
+1100 VFW Parkway (Gordon's Wood),completed,2015,42,0,42.28395893,-71.17140596,Boston,Metropolitan Area Planning Council
+interior fit-out,completed,2015,0,3000,42.24876034,-70.90382395,Hingham,Metropolitan Area Planning Council
+47 Waltham Street,completed,2015,1,0,42.34220722,-71.06918829,Boston,Metropolitan Area Planning Council
+Georgetowne Homes Preservation Project,completed,2015,967,0,42.25840807,-71.1467721,Boston,Metropolitan Area Planning Council
+LA Fitness Club (West Roxbury),completed,2015,0,48900,42.27824761,-71.16915937,Boston,Metropolitan Area Planning Council
+4040 Washington Street,completed,2015,28,0,42.29130832,-71.12231624,Boston,Metropolitan Area Planning Council
+Nazing Court Apartments,completed,2015,151,0,42.307179,-71.08765244,Boston,Metropolitan Area Planning Council
+9 Glen Street,completed,2015,2,0,42.27292433,-71.39641335,Framingham,Metropolitan Area Planning Council
+Cimpress Office Building,completed,2015,0,315000,42.40584492,-71.25581726,Waltham,Metropolitan Area Planning Council
+66 Sleeper Street,completed,2015,0,85890,42.35259894,-71.04615892,Boston,Metropolitan Area Planning Council
+36 River Street,completed,2015,200,0,42.36757479,-71.21697293,Waltham,Metropolitan Area Planning Council
+22-26 West Broadway Street,completed,2015,31,3834,42.3428041,-71.05664344,Boston,Metropolitan Area Planning Council
+1522 VFW Parkway,completed,2015,15,0,42.26856295,-71.17097185,Boston,Metropolitan Area Planning Council
+162 Santilli Hwy - (Best Buy),completed,2015,0,30038,42.40348003,-71.06767325,Everett,Metropolitan Area Planning Council
+376 West Fourth Street,completed,2015,18,0,42.3370799,-71.04975581,Boston,Metropolitan Area Planning Council
+Ridge Estates,completed,2015,7,0,42.07175341,-71.34514019,Wrentham,Metropolitan Area Planning Council
+E Street Self Storage,completed,2015,0,98000,42.34048408,-71.04750608,Boston,Metropolitan Area Planning Council
+22 Liberty (Fan Pier),completed,2015,118,0,42.3547,-71.0454,Boston,Metropolitan Area Planning Council
+MGH Museum and History Center,completed,2015,0,8000,42.36191342,-71.06828228,Boston,Metropolitan Area Planning Council
+Proprietors Market Place,completed,2015,0,34000,42.10351389,-70.74339034,Marshfield,Metropolitan Area Planning Council
+Newbridge Village at 855 Main Street,completed,2015,91,0,42.50475596,-71.15904808,Woburn,Metropolitan Area Planning Council
+Walden Woods at Stenbeck Place,completed,2015,28,0,42.19512382,-70.73243167,Scituate,Metropolitan Area Planning Council
+Quonahassit Trail,completed,2015,6,0,42.24256315,-70.81612391,Cohasset,Metropolitan Area Planning Council
+Assembly Row: Block 11 (Phase 1),completed,2015,0,874297,42.3916,-71.0786,Somerville,Metropolitan Area Planning Council
+415 McClellan Highway,completed,2015,0,117060,42.3901,-71.0127,Boston,Metropolitan Area Planning Council
+East Lenox St. & Washington St.,completed,2015,25,1450,42.33613578,-71.08010231,Boston,Metropolitan Area Planning Council
+525-527 East Second Street Condominiums,completed,2015,13,0,42.33702715,-71.04216112,Boston,Metropolitan Area Planning Council
+Wheelock College - Resource Center,completed,2015,0,6545,42.34294681,-71.10523423,Boston,Metropolitan Area Planning Council
+Lord Hobo Brewery,completed,2015,0,47000,42.47621035,-71.12887817,Woburn,Metropolitan Area Planning Council
+Needham Bank Expansion,completed,2015,0,12363,42.28066278,-71.23811877,Needham,Metropolitan Area Planning Council
+St Mark's School STEM building,completed,2015,0,29000,42.30964597,-71.53401857,Southborough,Metropolitan Area Planning Council
+Joslin Diabetes Center Expansion Project (Phase 1),completed,2015,189,350000,42.33865914,-71.10831661,Boston,Metropolitan Area Planning Council
+136-146 Northern Ave,completed,2015,369,0,42.350951,-71.042982,Boston,Metropolitan Area Planning Council
+72-74 London,completed,2015,6,0,42.3719154,-71.0405025,Boston,Metropolitan Area Planning Council
+Boston University - School of Law,completed,2015,0,93525,42.35063597,-71.10656723,Boston,Metropolitan Area Planning Council
+Staples (Roslindale),completed,2015,0,19300,42.28839962,-71.12705724,Boston,Metropolitan Area Planning Council
+"CarMax Auto Superstores, Inc.",completed,2015,0,135200,42.16774286,-71.19503679,Norwood,Metropolitan Area Planning Council
+Bay Oaks,completed,2015,4,0,42.15702949,-71.4679309,Medway,Metropolitan Area Planning Council
+130 Cabot,completed,2015,11,4000,42.54665686,-70.8800805,Beverly,Metropolitan Area Planning Council
+Lifetime Fitness - 432/490 Old Connecticut Path,completed,2015,0,137300,42.31281034,-71.39463321,Framingham,Metropolitan Area Planning Council
+Bernardi Toyota - 1626 Worcester Road,completed,2015,0,50536,42.29593882,-71.47193657,Framingham,Metropolitan Area Planning Council
+34-36 St. James Street in Roxbury,completed,2015,4,0,42.32616964,-71.0857478,Boston,Metropolitan Area Planning Council
+125 Newbury Street,completed,2015,0,15,42.30735318,-71.39624114,Framingham,Metropolitan Area Planning Council
+"Longwood Center - Research, Clinical, Retail & Parking",completed,2015,0,414000,42.33902848,-71.10810529,Boston,Metropolitan Area Planning Council
+Bass River Estates,completed,2015,11,0,42.54685558,-70.8910989,Beverly,Metropolitan Area Planning Council
+429 Gallivan Blvd,completed,2015,18,0,42.28148838,-71.05938413,Boston,Metropolitan Area Planning Council
+Village of the Americas,completed,2015,528,21000,42.25398105,-71.45164751,Ashland,Metropolitan Area Planning Council
+39 Grant Street,completed,2015,79,0,42.27934079,-71.41094682,Framingham,Metropolitan Area Planning Council
+Chestnut Hill Square,completed,2015,91,243000,42.318906,-71.175186,Newton,Metropolitan Area Planning Council
+Walpole Mall Expansion,completed,2015,0,120000,42.15447212,-71.20240464,Walpole,Metropolitan Area Planning Council
+79 Rogers Ave,completed,2015,3,,42.39795236,-71.11220448,Somerville,Metropolitan Area Planning Council
+60-66 Brainerd Road,completed,2015,79,0,42.34745249,-71.13312962,Boston,Metropolitan Area Planning Council
+1019 Trapelo Road,completed,2015,0,9750,42.4111826,-71.2332094,Waltham,Metropolitan Area Planning Council
+85 West Main St.,completed,2015,0,7430,42.21687832,-71.54136495,Hopkinton,Metropolitan Area Planning Council
+26 Weston Ave,completed,2015,16,0,42.40323058,-71.12877256,Somerville,Metropolitan Area Planning Council
+Market Street at Lynnfield,completed,2015,180,475000,42.5190877,-71.03550195,Lynnfield,Metropolitan Area Planning Council
+"CVS - 480-498 Concord Street, 7 Lindbergh",completed,2015,0,15195,42.28901258,-71.40970843,Framingham,Metropolitan Area Planning Council
+The Village At Magnolia Shores,completed,2015,44,0,42.58448507,-70.71062479,Gloucester,Metropolitan Area Planning Council
+10-18 Merrymount Road,completed,2015,23,0,42.25661265,-71.00647167,Quincy,Metropolitan Area Planning Council
+Charlesview Redevelopment,completed,2015,340,0,42.36319913,-71.13888862,Boston,Metropolitan Area Planning Council
+1 Worcester Road - Peir 1 Imports,completed,2015,0,15000,42.30185748,-71.3954529,Framingham,Metropolitan Area Planning Council
+Target Superstore,completed,2015,0,139000,42.58946185,-71.16059496,Wilmington,Metropolitan Area Planning Council
+Orchard Homeownership Initiative,completed,2015,20,,42.32777266,-71.07643774,Boston,Metropolitan Area Planning Council
+30 Hazelwood,completed,2015,2,0,42.31758928,-71.0842969,Boston,Metropolitan Area Planning Council
+11 East ST,completed,2015,0,4200,42.59640579,-70.99217698,Middleton,Metropolitan Area Planning Council
+Chic-fil-A,completed,2015,0,4815,42.3033,-71.3985,Framingham,Metropolitan Area Planning Council
+208 Dudley Street,completed,2015,0,1920,42.32868545,-71.08107535,Boston,Metropolitan Area Planning Council
+Continuum ,completed,2015,325,45000,42.36345542,-71.1303928,Boston,Metropolitan Area Planning Council
+University Station,completed,2015,728,850000,42.20729346,-71.15278689,Westwood,Metropolitan Area Planning Council
+"246 Boston Street, ",completed,2015,9,0,42.32142635,-71.06116696,Boston,Metropolitan Area Planning Council
+Allied Waste Systems Transfer Station,completed,2015,0,40000,42.32847425,-71.07304598,Boston,Metropolitan Area Planning Council
+Massachusetts General Hospital - Building for 3rd Century,completed,2015,0,0,42.36269128,-71.06967293,Boston,Metropolitan Area Planning Council
+18 Robert st,completed,2015,12,0,42.287437,-71.132841,Boston,Metropolitan Area Planning Council
+Quincy Commons 202,completed,2015,40,0,42.314774,-71.078457,Boston,Metropolitan Area Planning Council
+125 Condor Street,completed,2015,7,0,42.38241495,-71.03545195,Boston,Metropolitan Area Planning Council
+Jack Flats,completed,2015,212,0,42.44342979,-71.07109176,Melrose,Metropolitan Area Planning Council
+Bruce C. Bolling Municipal Building,completed,2015,0,200000,42.33014892,-71.08366304,Boston,Metropolitan Area Planning Council
+GrandMarc Residence Hall at Northeastern University,completed,2015,0,0,42.34076433,-71.08702578,Boston,Metropolitan Area Planning Council
+14 I Street,completed,2015,9,0,42.337587,-71.039862,Boston,Metropolitan Area Planning Council
+Harvard University (Allston): Baker/Esteves Hall,completed,2015,0,0,42.3672399,-71.12049328,Boston,Metropolitan Area Planning Council
+267 Medford,completed,2015,121,0,42.381307,-71.06155,Boston,Metropolitan Area Planning Council
+400 Western Avenue,completed,2015,20,0,42.3621384,-71.13906042,Boston,Metropolitan Area Planning Council
+77-91 Seaport Blvd,completed,2015,346,0,42.35198614,-71.04493931,Boston,Metropolitan Area Planning Council
+30-36 Traveler St,completed,2015,77,0,42.34453614,-71.0635711,Boston,Metropolitan Area Planning Council
+516 Columbia Rd,completed,2015,33,0,42.31522076,-71.06721787,Boston,Metropolitan Area Planning Council
+10-30 Gleason,completed,2015,8,0,42.2978243,-71.08218133,Boston,Metropolitan Area Planning Council
+Williamsburg Condominium,completed,2015,18,0,42.14299922,-71.45811659,Medway,Metropolitan Area Planning Council
+861 E Second,completed,2015,6,0,42.33727018,-71.02847725,Boston,Metropolitan Area Planning Council
+22-26 Hawthorne,completed,2015,8,0,42.32424238,-71.09149655,Boston,Metropolitan Area Planning Council
+8 Dustin,completed,2015,9,0,42.35114176,-71.14631659,Boston,Metropolitan Area Planning Council
+109-123 Dresser,completed,2015,5,0,42.33730157,-71.04429733,Boston,Metropolitan Area Planning Council
+585 E Seventh St,completed,2015,5,0,42.332108,-71.036843,Boston,Metropolitan Area Planning Council
+"51 Chelsa, east boston ",completed,2015,8,0,42.37105014,-71.03706319,Boston,Metropolitan Area Planning Council
+"53 Chelsa, east boston ",completed,2015,8,0,42.37110459,-71.03703421,Boston,Metropolitan Area Planning Council
+15 Preble St,completed,2015,9,0,42.329177,-71.056481,Boston,Metropolitan Area Planning Council
+191 W Eighth,completed,2015,6,0,42.333548,-71.052115,Boston,Metropolitan Area Planning Council
+17-25  Piedmont St ,completed,2015,8,0,42.34983833,-71.06824238,Boston,Metropolitan Area Planning Council
+2 G ST,completed,2015,4,0,42.33619537,-71.04417787,Boston,Metropolitan Area Planning Council
+"115 Pleasant, Boston, MA 02128",completed,2015,6,0,42.31171687,-71.05938084,Boston,Metropolitan Area Planning Council
+48 Gold St,completed,2015,9,0,42.33986654,-71.05519699,Boston,Metropolitan Area Planning Council
+Forest Hills Parcel V&W,completed,2015,0,48000,42.29763843,-71.11662354,Boston,Metropolitan Area Planning Council
+"Cambridgepark Dr., #165 Phased",completed,2015,247,0,42.39560317,-71.14751181,Cambridge,Metropolitan Area Planning Council
+Canton Street Group Home,completed,2015,1,0,42.1363049,-71.17187544,Sharon,Metropolitan Area Planning Council
+1 Education St.,completed,2015,0,295000,42.36980516,-71.06872473,Cambridge,Metropolitan Area Planning Council
+Parcel 24,completed,2015,217,0,42.34946354,-71.06031339,Boston,Metropolitan Area Planning Council
+261 LEXINGTON,completed,2015,6,0,42.380337,-71.030264,Boston,Metropolitan Area Planning Council
+20 Child St. / North Point Bldg N,completed,2015,355,8257,42.37160137,-71.0714754,Cambridge,Metropolitan Area Planning Council
+500 Beach Street,completed,2015,7,0,42.410148,-70.998929,Revere,Metropolitan Area Planning Council
+473 Revere Beach Parkway,completed,2015,8,0,42.40451964,-71.00236677,Revere,Metropolitan Area Planning Council
+Salem Point ,completed,2015,77,0,42.51483594,-70.89287304,Salem,Metropolitan Area Planning Council
+Pier 4 - Phase 1,completed,2015,369,12600,42.35118784,-71.04320302,Boston,Metropolitan Area Planning Council
+Umass Boston General Academic Building No. 1 (University Hall),completed,2015,0,181000,42.31323261,-71.035231,Boston,Metropolitan Area Planning Council
+The Learning Tree,completed,2015,0,1,42.14741148,-71.42559938,Medway,Metropolitan Area Planning Council
+Fort Point Place,completed,2015,126,0,42.34711156,-71.05012778,Boston,Metropolitan Area Planning Council
+Homewood Suites,completed,2015,0,130000,42.20755912,-71.12219725,Canton,Metropolitan Area Planning Council
+319 A Street Rear,completed,2015,203,0,42.34868057,-71.04831444,Boston,Metropolitan Area Planning Council
+49-63 Melcher Street,completed,2015,52,113100,42.34944696,-71.05033269,Boston,Metropolitan Area Planning Council
+The Highlands at Canton Meadows,completed,2015,196,0,42.18116876,-71.08533197,Canton,Metropolitan Area Planning Council
+Seaport Square: Parcel L1 / 101 Seaport Boulevard,completed,2015,0,455300,42.35109546,-71.04545864,Boston,Metropolitan Area Planning Council
+Orchard Cove,completed,2015,45,0,42.17099122,-71.11315169,Canton,Metropolitan Area Planning Council
+143 Cedar Street,completed,2015,10,0,42.39340037,-71.11127369,Somerville,Metropolitan Area Planning Council
+97 Prospect Street,completed,2015,7,0,42.37559977,-71.09684421,Somerville,Metropolitan Area Planning Council
+39 Cameron/43 Elmwood,completed,2015,7,0,42.3993162,-71.12718117,Somerville,Metropolitan Area Planning Council
+170 School Street,completed,2015,5,0,42.388994,-71.097521,Somerville,Metropolitan Area Planning Council
+595 Somerville Ave,completed,2015,4,0,42.38401395,-71.10920746,Somerville,Metropolitan Area Planning Council
+168 School Street,completed,2015,22,0,42.24393658,-71.00794071,Quincy,Metropolitan Area Planning Council
+Meadowview Estates Subdivision,completed,2015,5,0,42.07538786,-71.30039501,Wrentham,Metropolitan Area Planning Council
+92 Lafayette Street,completed,2015,8,0,42.51838058,-70.89361053,Salem,Metropolitan Area Planning Council
+292 Beacon St,completed,2015,2,0,42.38340886,-71.11306344,Somerville,Metropolitan Area Planning Council
+308 Beacon St,completed,2015,6,0,42.38390471,-71.11368454,Somerville,Metropolitan Area Planning Council
+Wentworth - Ira Allen Building Addition,completed,2015,0,18000,42.33617801,-71.09391727,Boston,Metropolitan Area Planning Council
+Convention Center Hotel,completed,2015,0,34000,42.3459953,-71.04331329,Boston,Metropolitan Area Planning Council
+120 Waverly Street - Framingham Salvage Co.,completed,2015,0,11461,42.27924704,-71.40403879,Framingham,Metropolitan Area Planning Council
+140 Cambridgepark Drive Garage,completed,2015,0,0,42.39404098,-71.14642116,Cambridge,Metropolitan Area Planning Council
+Wentworth - Flanagan Campus Center at Beatty Hall,completed,2015,0,30000,42.33559602,-71.09562923,Boston,Metropolitan Area Planning Council
+Riverside,completed,2015,1,0,42.47139273,-71.63155062,Bolton,Metropolitan Area Planning Council
+Ridgecrest Village Apartments,completed,2015,48,0,42.25857241,-71.15051867,Boston,Metropolitan Area Planning Council
+Roxbury Tenants of Harvard Community Center,completed,2015,0,28000,42.33508172,-71.10945438,Boston,Metropolitan Area Planning Council
+Salem Waterfront Hotel Expansion,cancelled,2016,0,72574,42.51975986,-70.89013522,Salem,Metropolitan Area Planning Council
+Boston Landing - 80 Guest Street,completed,2016,0,297000,42.35721156,-71.14236286,Boston,Metropolitan Area Planning Council
+Holiday Inn Express Expansion - 385 Winter Street,completed,2016,0,17875,42.39852649,-71.25853627,Waltham,Metropolitan Area Planning Council
+Ashland Woods,completed,2016,48,0,42.24287357,-71.48522059,Ashland,Metropolitan Area Planning Council
+Residences at Malden Station,completed,2016,84,,42.4276492,-71.07364894,Malden,Metropolitan Area Planning Council
+Hampton Inn,completed,2016,0,15000,42.40128584,-71.00645878,Revere,Metropolitan Area Planning Council
+Knight Circle,completed,2016,2,0,42.57757812,-70.77070471,Manchester,Metropolitan Area Planning Council
+Beauport Hotel Gloucester,completed,2016,0,85464,42.60947458,-70.66539563,Gloucester,Metropolitan Area Planning Council
+Olmsted Place (161 South Huntington),completed,2016,196,49000,42.32692796,-71.11190173,Boston,Metropolitan Area Planning Council
+Boston College - McMullen Museum and University Conference Space,completed,2016,0,7100,42.33940664,-71.16512666,Boston,Metropolitan Area Planning Council
+Centre Lamartine,completed,2016,30,7900,42.32258784,-71.1009875,Boston,Metropolitan Area Planning Council
+The Washingtons Apartments,completed,2016,182,,42.44012354,-71.07247627,Melrose,Metropolitan Area Planning Council
+30 Dalton St,completed,2016,222,1351,42.34594508,-71.08474982,Boston,Metropolitan Area Planning Council
+One Upland,completed,2016,262,,42.20529745,-71.20546046,Norwood,Metropolitan Area Planning Council
+55 Seaport Boulevard,completed,2016,0,13550,42.35258583,-71.04785625,Boston,Metropolitan Area Planning Council
+Port Landing,completed,2016,20,0,42.36550941,-71.09372154,Cambridge,Metropolitan Area Planning Council
+Pine Meadow Medway,completed,2016,8,0,42.14431008,-71.45208596,Medway,Metropolitan Area Planning Council
+160 Green Street,completed,2016,6,0,42.46557501,-71.05959869,Melrose,Metropolitan Area Planning Council
+Hingham Affordable Housing Trust,completed,2016,8,0,42.24170147,-70.91007364,Hingham,Metropolitan Area Planning Council
+Monsen Road Subdivision,completed,2016,8,0,42.47382691,-71.32579668,Concord,Metropolitan Area Planning Council
+Ice House Landing,completed,2016,60,0,42.34398449,-71.57224461,Marlborough,Metropolitan Area Planning Council
+Marriott Hotel,completed,2016,0,105652,42.36291027,-71.15490109,Watertown,Metropolitan Area Planning Council
+Mass College of Art - Design & Media Center,completed,2016,0,40000,42.33679668,-71.09960518,Boston,Metropolitan Area Planning Council
+One North of Boston Phase 2 - 150 Heard Street,completed,2016,222,0,42.39961444,-71.03714925,Chelsea,Metropolitan Area Planning Council
+Horseshoe Farm,completed,2016,24,0,42.15411306,-70.75345964,Marshfield,Metropolitan Area Planning Council
+DECO (625 Thomas Burgin Parkway),completed,2016,180,0,42.23424526,-71.00864106,Quincy,Metropolitan Area Planning Council
+Avalon Bay on Quarry Street,completed,2016,398,0,42.24809579,-71.01715663,Quincy,Metropolitan Area Planning Council
+The Eddy,completed,2016,259,0,42.37121432,-71.0439642,Boston,Metropolitan Area Planning Council
+Triple 9 Brookside,completed,2016,53,0,42.25752112,-71.00874296,Quincy,Metropolitan Area Planning Council
+Artis Senior Living,completed,2016,0,36125,42.54247908,-71.10501757,Reading,Metropolitan Area Planning Council
+407-413 Pleasant Street,completed,2016,2,0,42.44994721,-71.07027989,Melrose,Metropolitan Area Planning Council
+Rock Chapel Marine,completed,2016,0,5349,42.38625979,-71.03393655,Chelsea,Metropolitan Area Planning Council
+Endicott College Dorm,completed,2016,49,94700,42.55641906,-70.8461451,Beverly,Metropolitan Area Planning Council
+11 On the Dot,completed,2016,30,0,42.33721153,-71.04375635,Boston,Metropolitan Area Planning Council
+Brierneck Crossing,completed,2016,12,0,42.62412645,-70.63046133,Gloucester,Metropolitan Area Planning Council
+Acorn Estates at Canton Hills ,completed,2016,25,0,42.18239909,-71.08810222,Canton,Metropolitan Area Planning Council
+300 Massachusetts Ave (University Park Millenium Bldg),completed,2016,0,218500,42.3619907,-71.09891088,Cambridge,Metropolitan Area Planning Council
+Benfield Farms,completed,2016,26,,42.50916976,-71.38017217,Carlisle,Metropolitan Area Planning Council
+Post Office Square,completed,2016,12,0,42.48861479,-71.42379521,Acton,Metropolitan Area Planning Council
+Redevelopment of 130/180 Third Avenue,completed,2016,0,399000,42.39249757,-71.26077034,Waltham,Metropolitan Area Planning Council
+The Whitwell,completed,2016,15,0,42.35958672,-71.06415716,Boston,Metropolitan Area Planning Council
+45 Marion Street,completed,2016,64,0,42.34037729,-71.12371508,Brookline,Metropolitan Area Planning Council
+Amazon Distribution Center - (201 Beecham Street),completed,2016,0,206622,42.39353615,-71.05323506,Everett,Metropolitan Area Planning Council
+3 Webster,completed,2016,6,0,42.52716462,-70.88889869,Salem,Metropolitan Area Planning Council
+267 Great Road,completed,2016,0,3605,42.49543444,-71.41556935,Acton,Metropolitan Area Planning Council
+"Wingate Senior Living at Needham, Inc.",completed,2016,52,0,42.30117275,-71.23102412,Needham,Metropolitan Area Planning Council
+MGH Building for Third Century - 255 Charles Street,completed,2016,0,530000,42.36315524,-71.06852783,Boston,Metropolitan Area Planning Council
+Grimes Crossing,completed,2016,27,0,42.1563984,-71.14080106,Canton,Metropolitan Area Planning Council
+Hayward Place,completed,2016,277,19000,42.35337869,-71.06198676,Boston,Metropolitan Area Planning Council
+"Jackson Square: Phase I, 1562 Columbus Ave (Jackson Commons)",completed,2016,37,12000,42.32293059,-71.09811419,Boston,Metropolitan Area Planning Council
+Connelly Hill Estates,completed,2016,60,0,42.19833319,-71.49600825,Hopkinton,Metropolitan Area Planning Council
+The Boston Conservatory - 132 Ipswich Street,completed,2016,0,20000,42.34722004,-71.09381804,Boston,Metropolitan Area Planning Council
+Black Birch Phase I,completed,2016,25,0,42.43758866,-71.42141625,Concord,Metropolitan Area Planning Council
+2 Sharp St,completed,2016,0,5750,42.16198266,-70.91631379,Hingham,Metropolitan Area Planning Council
+888 Boylston Street,completed,2016,0,425000,42.3481873,-71.08297352,Boston,Metropolitan Area Planning Council
+Roxbury Latin Athletic Facilities Expansion,completed,2016,0,47580,42.27560454,-71.15643414,Boston,Metropolitan Area Planning Council
+Seaport Square: Parcel K (Watermark),completed,2016,346,25000,42.35167453,-71.04623534,Boston,Metropolitan Area Planning Council
+Preserve at Oregon,completed,2016,24,,42.28213827,-71.49392136,Ashland,Metropolitan Area Planning Council
+Modera Natick Center,completed,2016,138,,42.28943444,-71.35331385,Natick,Metropolitan Area Planning Council
+Main & Winter,completed,2016,0,275000,42.20123225,-70.95426414,Weymouth,Metropolitan Area Planning Council
+The Meadows at Acton,completed,2016,26,0,42.49466063,-71.41506798,Acton,Metropolitan Area Planning Council
+339 D Street,completed,2016,24,0,42.34022616,-71.04882275,Boston,Metropolitan Area Planning Council
+Medford Mews,completed,2016,347,0,42.40742647,-71.07559133,Medford,Metropolitan Area Planning Council
+Ballardvale Office Park,completed,2016,0,12000,42.58976314,-71.15553692,Wilmington,Metropolitan Area Planning Council
+Lucky Strike Residential Project,completed,2016,22,7875,42.29941024,-71.05863259,Boston,Metropolitan Area Planning Council
+Talia Apartments,completed,2016,225,0,42.33568164,-71.59191257,Marlborough,Metropolitan Area Planning Council
+49-51 Waltham,completed,2016,6,0,42.41950366,-71.45970269,Maynard,Metropolitan Area Planning Council
+Everett Community Health and Wellness Center,completed,2016,0,325000,42.4106627,-71.05372939,Everett,Metropolitan Area Planning Council
+The Residences at Hooper Mansion,completed,2016,6,0,42.35175978,-71.08730354,Boston,Metropolitan Area Planning Council
+20 Fort Street,completed,2016,17,0,42.24420572,-71.00658632,Quincy,Metropolitan Area Planning Council
+Everly Apartments (14 Audubon Rd),completed,2016,186,0,42.51542373,-71.04325386,Wakefield,Metropolitan Area Planning Council
+"100 Putnam Ave. / MLK, JR. School",completed,2016,0,169221,42.3666148,-71.11481562,Cambridge,Metropolitan Area Planning Council
+15 - 33 Richdale Ave.,completed,2016,46,0,42.38860181,-71.12208503,Cambridge,Metropolitan Area Planning Council
+Verb Hotel,completed,2016,184,4000,42.34530629,-71.0969356,Boston,Metropolitan Area Planning Council
+130 Tremont Street,completed,2016,26,0,42.46345495,-71.06989471,Melrose,Metropolitan Area Planning Council
+60 State Street,completed,2016,0,250,42.35936066,-71.05639249,Boston,Metropolitan Area Planning Council
+33 Cottage Park Ave.,completed,2016,67,0,42.39833084,-71.13376544,Cambridge,Metropolitan Area Planning Council
+Vanguard at Waterfront Square,completed,2016,166,0,42.41719783,-70.98907664,Revere,Metropolitan Area Planning Council
+Washington Place Condominiums,completed,2016,22,2500,42.4141856,-71.03215391,Revere,Metropolitan Area Planning Council
+Lovejoy Wharf - Hoffman Building,completed,2016,0,207730,42.36703034,-71.06008609,Boston,Metropolitan Area Planning Council
+Bloomfield Gardens,completed,2016,27,,42.299574,-71.06541234,Boston,Metropolitan Area Planning Council
+Envoy Hotel,completed,2016,0,17778,42.35366644,-71.04832812,Boston,Metropolitan Area Planning Council
+Rumney Flats Apartments,completed,2016,231,0,42.42539233,-71.00608371,Revere,Metropolitan Area Planning Council
+The Academy at Penguin Hall,completed,2016,0,105000,42.59347887,-70.84704216,Wenham,Metropolitan Area Planning Council
+Marriott Hotel,completed,2016,0,82370,42.46229545,-71.38938857,Concord,Metropolitan Area Planning Council
+92 Franklin Street,completed,2016,3,0,42.46707285,-71.062911,Melrose,Metropolitan Area Planning Council
+McKay School Redevelopment,completed,2016,32,0,42.56416024,-70.89303644,Beverly,Metropolitan Area Planning Council
+197 Union Square,completed,2016,30,3502,42.37925384,-71.09553012,Somerville,Metropolitan Area Planning Council
+200 Boston Avenue,completed,2016,0,60000,42.41556021,-71.12672433,Medford,Metropolitan Area Planning Council
+488 Dorchester Avenue,completed,2016,33,2091,42.33203273,-71.05665995,Boston,Metropolitan Area Planning Council
+189 Broadway Senior Housing,completed,2016,39,0,42.40621375,-71.01443287,Revere,Metropolitan Area Planning Council
+Blanchard Farm Estates,completed,2016,11,0,42.20938568,-70.76338425,Scituate,Metropolitan Area Planning Council
+Lofts at 888 Tremont Street,completed,2016,9,0,42.33778971,-71.08253816,Boston,Metropolitan Area Planning Council
+Waltham Landing,completed,2016,34,8260,42.26943182,-71.09155591,Boston,Metropolitan Area Planning Council
+Excel Academy Charter Middle and High School,completed,2016,0,70000,42.3784304,-71.02681878,Boston,Metropolitan Area Planning Council
+Jonathan's Landing ,completed,2016,318,,42.19884315,-70.99648603,Braintree,Metropolitan Area Planning Council
+Bridgeview Center,completed,2016,60,10000,42.37886861,-71.07138324,Boston,Metropolitan Area Planning Council
+"Brookside Square, 50 Beharrell",completed,2016,74,30000,42.45842643,-71.39502694,Concord,Metropolitan Area Planning Council
+Peloquin Estates,completed,2016,9,0,42.22761972,-71.48838757,Hopkinton,Metropolitan Area Planning Council
+Residences at Quail Ridge,completed,2016,174,0,42.50755572,-71.42178481,Acton,Metropolitan Area Planning Council
+270 Third St.,completed,2016,91,8506,42.36598839,-71.081663,Cambridge,Metropolitan Area Planning Council
+Brighton Landing - South Parking Garage,completed,2016,0,0,42.3567634,-71.14679671,Boston,Metropolitan Area Planning Council
+Maria Sanchez House,completed,2016,40,0,42.33227896,-71.09591302,Boston,Metropolitan Area Planning Council
+The Tremont (32 Second Ave),completed,2016,180,0,42.485702,-71.22291632,Burlington,Metropolitan Area Planning Council
+82 Highland Ave,completed,2016,6,0,42.38627162,-71.09775738,Somerville,Metropolitan Area Planning Council
+42 Main St.,completed,2016,0,14,42.22898716,-71.52122163,Hopkinton,Metropolitan Area Planning Council
+Mariano Drive,completed,2016,3,0,42.55656567,-71.11231411,Reading,Metropolitan Area Planning Council
+Angier Elementary School,completed,2016,0,23000,42.32650382,-71.2326188,Newton,Metropolitan Area Planning Council
+Lower Mills Apartments,completed,2016,177,0,42.27300001,-71.06731162,Boston,Metropolitan Area Planning Council
+Parc at Medfield,completed,2016,92,0,42.19104998,-71.32853037,Medfield,Metropolitan Area Planning Council
+600 Harrison Avenue,completed,2016,160,3600,42.34025123,-71.06764529,Boston,Metropolitan Area Planning Council
+75 | 125 Binney,completed,2016,0,380000,42.36585586,-71.08055241,Cambridge,Metropolitan Area Planning Council
+Cape Ann Forge,completed,2016,10,0,42.6184911,-70.67743681,Gloucester,Metropolitan Area Planning Council
+Collin Farm - 505 Pleasant Street,completed,2016,8,0,42.30464974,-71.45953746,Framingham,Metropolitan Area Planning Council
+Millbrook Lofts,completed,2016,100,0,42.37415873,-71.08698225,Somerville,Metropolitan Area Planning Council
+380 Bunker Hill Street Charlestown Armory,completed,2016,42,0,42.38220759,-71.0688416,Boston,Metropolitan Area Planning Council
+1085 Boylston Street,completed,2016,30,0,42.34721495,-71.08895916,Boston,Metropolitan Area Planning Council
+The Residences at St. Augustine,completed,2016,29,0,42.33327004,-71.05089846,Boston,Metropolitan Area Planning Council
+Jack's Abby,completed,2016,0,0,42.2802,-71.411,Framingham,Metropolitan Area Planning Council
+Middlesex School Residence Hall,completed,2016,29,19308,42.496,-71.368,Concord,Metropolitan Area Planning Council
+Wellington Parkside,completed,2016,190,0,42.40831803,-71.06444116,Everett,Metropolitan Area Planning Council
+The Merc,completed,2016,269,27500,42.3758,-71.2374,Waltham,Metropolitan Area Planning Council
+900 Beacon Street,completed,2016,32,4470,42.34683939,-71.10576261,Boston,Metropolitan Area Planning Council
+Concord Academy Science Center,completed,2016,0,18000,42.46040105,-71.35513908,Concord,Metropolitan Area Planning Council
+Boston College Dorm Conversion (2000 Commonwealth),completed,2016,0,0,42.33944737,-71.15859291,Boston,Metropolitan Area Planning Council
+Temple Place Apartments - 5 Temple Street,completed,2016,40,0,42.36669017,-71.10416388,Cambridge,Metropolitan Area Planning Council
+299 Dudley St Apartments,completed,2016,12,,42.32785795,-71.07789518,Boston,Metropolitan Area Planning Council
+Avalon North Station,completed,2016,503,3575,42.36594674,-71.06329312,Boston,Metropolitan Area Planning Council
+945 East Broadway,completed,2016,10,0,42.33551483,-71.02607859,Boston,Metropolitan Area Planning Council
+Elliott Landing,completed,2016,65,0,42.55695162,-70.88783656,Beverly,Metropolitan Area Planning Council
+Charles River Village,completed,2016,11,0,42.1376209,-71.40602018,Medway,Metropolitan Area Planning Council
+178-186 E. Howard Street,completed,2016,12,0,42.24270288,-70.97804399,Quincy,Metropolitan Area Planning Council
+Cranberry Cove,completed,2016,13,0,42.1084284,-70.69874654,Marshfield,Metropolitan Area Planning Council
+485 East Central Street - Franklin Retirement,completed,2016,181,0,42.08063644,-71.37574821,Franklin,Metropolitan Area Planning Council
+Kensington Place - Hinge Block,completed,2016,299,4200,42.35175319,-71.06321498,Boston,Metropolitan Area Planning Council
+Millenium Tower,completed,2016,450,30000,42.35569106,-71.05944963,Boston,Metropolitan Area Planning Council
+333-339 West Broadway,completed,2016,15,2600,42.33804231,-71.05024671,Boston,Metropolitan Area Planning Council
+1699 Worcester Road - Wendys,completed,2016,0,3825,42.2975633,-71.48396214,Framingham,Metropolitan Area Planning Council
+Seville Boston Harbor,completed,2016,66,15000,42.37616251,-71.03948812,Boston,Metropolitan Area Planning Council
+Currents on the Charles - 33 River St,completed,2016,34,0,42.3683603,-71.21661105,Waltham,Metropolitan Area Planning Council
+Commonwealth Residences,completed,2016,52,,42.32327295,-71.34750338,Wayland,Metropolitan Area Planning Council
+Middlesex Green - 521 to 575 Virginia Rd,completed,2016,0,288430,42.46777631,-71.30358417,Concord,Metropolitan Area Planning Council
+168 Third Ave,completed,2016,0,129000,42.39495892,-71.26519939,Waltham,Metropolitan Area Planning Council
+Bedford Marketplace,completed,2016,0,147000,42.49088067,-71.27338997,Bedford,Metropolitan Area Planning Council
+Suffolk University- 20 Somerset Street,completed,2016,0,156000,42.35968822,-71.06184126,Boston,Metropolitan Area Planning Council
+Highland Park III,completed,2016,3,0,42.25729633,-71.54553382,Hopkinton,Metropolitan Area Planning Council
+West of Chestnut,completed,2016,169,0,42.24963165,-71.00203084,Quincy,Metropolitan Area Planning Council
+BUMC- New Ambulatory Care Center,completed,2016,0,245000,42.33499062,-71.07327426,Boston,Metropolitan Area Planning Council
+Boston College- 2150 Commonwealth Ave Residence Hall,completed,2016,0,0,42.33928307,-71.16496281,Boston,Metropolitan Area Planning Council
+Harvard University (Allston): Chao Center,completed,2016,0,75000,42.3666,-71.1199,Boston,Metropolitan Area Planning Council
+Kelleher Pond Subdivision,completed,2016,16,0,42.56723052,-70.86484074,Beverly,Metropolitan Area Planning Council
+9-25 Miner Street,completed,2016,49,0,42.34635671,-71.10317047,Boston,Metropolitan Area Planning Council
+Oxford Ping On Affordable Housing Project,completed,2016,67,0,42.35211409,-71.06037456,Boston,Metropolitan Area Planning Council
+Chelsea Station Restaurant Bar & Lounge,completed,2016,0,3100,42.39446361,-71.03906758,Chelsea,Metropolitan Area Planning Council
+Ferncroft Country Club,completed,2016,0,8564,42.60439343,-70.97815002,Middleton,Metropolitan Area Planning Council
+37/47 Washington Street,completed,2016,88,0,42.44142107,-71.07150815,Melrose,Metropolitan Area Planning Council
+33 H Street,completed,2016,6,0,42.33682547,-71.04177408,Boston,Metropolitan Area Planning Council
+71 Willow Ct,completed,2016,8,0,42.32456,-71.063624,Boston,Metropolitan Area Planning Council
+111 B Street,completed,2016,8,0,42.340921,-71.053413,Boston,Metropolitan Area Planning Council
+9 Cooper ST,completed,2016,6,0,42.36448204,-71.05595881,Boston,Metropolitan Area Planning Council
+893 E Second,completed,2016,9,0,42.33721,-71.02746,Boston,Metropolitan Area Planning Council
+"6	Ashland St",completed,2016,6,0,42.30074396,-71.05388408,Boston,Metropolitan Area Planning Council
+65-67 Lexington,completed,2016,7,0,42.37758757,-71.03738104,Boston,Metropolitan Area Planning Council
+281-289 Adams Street,completed,2016,22,0,42.374227,-71.058491,Boston,Metropolitan Area Planning Council
+164 Hichborn st,completed,2016,6,0,42.408642,-71.000597,Revere,Metropolitan Area Planning Council
+275 Old Colony Ave,completed,2016,14,0,42.330617,-71.053111,Boston,Metropolitan Area Planning Council
+273 D Street,completed,2016,24,0,42.33919627,-71.05003375,Boston,Metropolitan Area Planning Council
+110 Park St,completed,2016,8,0,42.299007,-71.058701,Boston,Metropolitan Area Planning Council
+25 Mercer ST,completed,2016,6,0,42.332696,-71.04915,Boston,Metropolitan Area Planning Council
+Benchmark Norwood,completed,2016,90,0,42.21341555,-71.193114,Norwood,Metropolitan Area Planning Council
+27 Washburn ST,completed,2016,7,0,42.325861,-71.058015,Boston,Metropolitan Area Planning Council
+Kaya Hotel,completed,2016,0,24162,42.38927422,-71.12033058,Cambridge,Metropolitan Area Planning Council
+610 Main Street North Phase 2,completed,2016,0,418000,42.3623853,-71.09400942,Cambridge,Metropolitan Area Planning Council
+145-149 Cedar St,completed,2016,6,0,42.327641,-71.094975,Boston,Metropolitan Area Planning Council
+24 Rawson St,completed,2016,7,0,42.325935,-71.05779383,Boston,Metropolitan Area Planning Council
+6-14 Fern St,completed,2016,6,0,42.359898,-71.133254,Boston,Metropolitan Area Planning Council
+30-30E Park St,completed,2016,6,0,42.35755373,-71.06271857,Boston,Metropolitan Area Planning Council
+542 Dorchester AV,completed,2016,9,0,42.330887,-71.056741,Boston,Metropolitan Area Planning Council
+22 WOODWARD,completed,2016,6,0,42.33159,-71.056139,Boston,Metropolitan Area Planning Council
+Reading Woods,completed,2016,424,0,42.50383178,-71.10838613,Reading,Metropolitan Area Planning Council
+16 Preble St,completed,2016,7,0,42.329615,-71.056369,Boston,Metropolitan Area Planning Council
+60 Holworthy,completed,2016,7,0,42.316254,-71.089554,Boston,Metropolitan Area Planning Council
+240 Sidney St.,completed,2016,96,0,42.35689529,-71.1062642,Cambridge,Metropolitan Area Planning Council
+Canton Street Condominiums,completed,2016,6,0,42.13557212,-71.17097344,Sharon,Metropolitan Area Planning Council
+43 Bridge Street ANR,completed,2016,6,0,42.532817,-70.887984,Salem,Metropolitan Area Planning Council
+Single Family ,completed,2016,1,0,42.515503,-70.903065,Salem,Metropolitan Area Planning Council
+10 Acorn Park (600 Discovery Park),completed,2016,0,82340,42.39875818,-71.14702296,Cambridge,Metropolitan Area Planning Council
+Hub25,completed,2016,278,0,42.31957862,-71.0512059,Boston,Metropolitan Area Planning Council
+100 Northern Avenue (Fan Pier Parcel I),completed,2016,0,515000,42.35219109,-71.04347003,Boston,Metropolitan Area Planning Council
+15R SPARHAWK,completed,2016,5,0,42.351244,-71.149286,Boston,Metropolitan Area Planning Council
+Residences at 319 A Street,completed,2016,48,0,42.34897825,-71.04904361,Boston,Metropolitan Area Planning Council
+Canton Ice House,completed,2016,0,65675,42.14140167,-71.12767161,Canton,Metropolitan Area Planning Council
+Brightview Canton,completed,2016,160,0,42.18226574,-71.11737628,Canton,Metropolitan Area Planning Council
+296 York Street Subdivision,completed,2016,3,0,42.17123311,-71.08931687,Canton,Metropolitan Area Planning Council
+Turtle Creek/ Village Gate,completed,2016,28,0,42.16189208,-71.10162002,Canton,Metropolitan Area Planning Council
+Beaver Meadow Estates (Herman Paul Road),completed,2016,9,0,42.1472547,-71.11754475,Canton,Metropolitan Area Planning Council
+The Estuary - Canton Point Condos,completed,2016,53,0,42.16719613,-71.11389675,Canton,Metropolitan Area Planning Council
+Union Point -- Faring Way,completed,2016,221,0,42.15933811,-70.94845575,Weymouth,Metropolitan Area Planning Council
+Union Point - Snowbird Development,completed,2016,26,0,42.15818714,-70.94597138,Weymouth,Metropolitan Area Planning Council
+Hewitts Landing Townhomes,completed,2016,150,0,42.25275393,-70.91597447,Hingham,Metropolitan Area Planning Council
+563-565 Broadway,completed,2016,10,4750,42.398552,-71.107482,Somerville,Metropolitan Area Planning Council
+197 Washington Street,completed,2016,30,0,42.37981784,-71.09155454,Somerville,Metropolitan Area Planning Council
+"19-21 Village St Somerville, MA 02143",completed,2016,7,0,42.38082203,-71.10547283,Somerville,Metropolitan Area Planning Council
+587-593 Somerville Ave,completed,2016,6,0,42.38398737,-71.10890982,Somerville,Metropolitan Area Planning Council
+47 Hunting Street,completed,2016,4,0,42.37421263,-71.09092878,Somerville,Metropolitan Area Planning Council
+NEEP Renovations and Expansion,completed,2016,0,329500,42.47790265,-71.19183846,Burlington,Metropolitan Area Planning Council
+Middleton Crossing,completed,2016,0,29227,42.58314408,-71.00723505,Middleton,Metropolitan Area Planning Council
+325 & 375 Assembly Row,completed,2016,0,7483,42.39280535,-71.07873263,Somerville,Metropolitan Area Planning Council
+Hayward Farm,completed,2016,6,0,42.48300453,-71.46401313,Acton,Metropolitan Area Planning Council
+6-8 Beacon St,completed,2016,6,0,42.37450686,-71.10210275,Somerville,Metropolitan Area Planning Council
+89 Wyman Street,completed,2016,4,0,42.49058896,-71.16714201,Woburn,Metropolitan Area Planning Council
+249 Cushing Street,completed,2016,2,0,42.19636442,-70.90033434,Hingham,Metropolitan Area Planning Council
+450 Cambridge Street,completed,2017,40,1631,42.35389491,-71.13559423,Boston,Metropolitan Area Planning Council
+Hancock Estates,completed,2017,88,,42.30434172,-71.16619364,Newton,Metropolitan Area Planning Council
+Emmerton House,completed,2017,6,0,42.52272837,-70.8843989,Salem,Metropolitan Area Planning Council
+21 Batchelder Street,completed,2017,0,3584,42.32185865,-71.06898062,Boston,Metropolitan Area Planning Council
+Continuum,completed,2017,325,45000,42.29642865,-71.07972062,Boston,Metropolitan Area Planning Council
+Whitney Place,completed,2017,88,0,42.09643351,-71.2209206,Sharon,Metropolitan Area Planning Council
+490 Old Conn Path,completed,2017,0,137300,42.31301504,-71.39472088,Framingham,Metropolitan Area Planning Council
+Lahey Hospital Emergency Center,completed,2017,0,41000,42.48489262,-71.20556691,Burlington,Metropolitan Area Planning Council
+380 Main Street,completed,2017,0,3300,42.47963911,-71.10000197,Stoneham,Metropolitan Area Planning Council
+HighRes Biosolutions,completed,2017,0,80000,42.57697573,-70.90757279,Beverly,Metropolitan Area Planning Council
+The Faretra,completed,2017,9,0,42.37430696,-71.03679229,Boston,Metropolitan Area Planning Council
+The Conrad,completed,2017,27,0,42.35620864,-71.06122064,Boston,Metropolitan Area Planning Council
+The Benjamin & VIA,completed,2017,832,250000,42.35311732,-71.04722044,Boston,Metropolitan Area Planning Council
+Constitution Wharf Renovation/ Addition,completed,2017,0,180000,42.37265733,-71.0560391,Boston,Metropolitan Area Planning Council
+65 Green Street,completed,2017,8,,42.31191394,-71.11056881,Boston,Metropolitan Area Planning Council
+One Gurney Street,completed,2017,40,31577,42.33188786,-71.09576952,Boston,Metropolitan Area Planning Council
+483 Somerville Avenue,completed,2017,3,,42.38296358,-71.10415552,Somerville,Metropolitan Area Planning Council
+Parcel 24 Phase II - 88 Hudson,completed,2017,51,0,42.34858843,-71.06077264,Boston,Metropolitan Area Planning Council
+Lovejoy Wharf - 100 Lovejoy Wharf,completed,2017,157,0,42.36733641,-71.0594584,Boston,Metropolitan Area Planning Council
+One Greenway / Parcel 24 - 66 Hudson ,completed,2017,95,3300,42.34994249,-71.06010961,Boston,Metropolitan Area Planning Council
+Auburn Court Apartments Expansion,completed,2017,9,,42.34842896,-71.09747205,Boston,Metropolitan Area Planning Council
+Urban Air Trampoline Park - Bellingham,completed,2017,0,35000,42.08267561,-71.45459149,Bellingham,Metropolitan Area Planning Council
+Joan and Edgar Booth Theatre - Boston University,completed,2017,0,75000,42.35020143,-71.11249663,Brookline,Metropolitan Area Planning Council
+The Landing Apartments,completed,2017,172,11000,42.22084084,-70.96888897,Braintree,Metropolitan Area Planning Council
+150 River's Edge Drive,completed,2017,282,0,42.41114587,-71.07587475,Medford,Metropolitan Area Planning Council
+Adelaide Way,completed,2017,15,0,42.07758603,-70.67352365,Marshfield,Metropolitan Area Planning Council
+Residence Inn Braintree,completed,2017,0,7040,42.2197805,-71.03441138,Braintree,Metropolitan Area Planning Council
+The Residences and Shops at Wakefield Station,completed,2017,60,8000,42.50091036,-71.07376782,Wakefield,Metropolitan Area Planning Council
+The Residence at Melrose Station,completed,2017,90,0,42.45652562,-71.0683982,Melrose,Metropolitan Area Planning Council
+Village at South River,completed,2017,14,,42.13917287,-70.69284011,Scituate,Metropolitan Area Planning Council
+Winter Garden Estates,completed,2017,5,0,42.0875959,-71.37624208,Franklin,Metropolitan Area Planning Council
+J. Henry Higgins Middle School,completed,2017,0,231000,42.52531387,-70.94258688,Peabody,Metropolitan Area Planning Council
+Abbey Road,completed,2017,18,0,42.2433721,-71.36968517,Sherborn,Metropolitan Area Planning Council
+163 Glen Street,completed,2017,11,0,42.38253686,-71.08847563,Somerville,Metropolitan Area Planning Council
+181 Washington Street,completed,2017,30,2413,42.38009169,-71.09110909,Somerville,Metropolitan Area Planning Council
+"Ingham Lane PRD, 1888 Main St",completed,2017,7,0,42.45013625,-71.41430204,Concord,Metropolitan Area Planning Council
+Collins Mansion Condominiums,completed,2017,9,0,42.33605492,-71.02685409,Boston,Metropolitan Area Planning Council
+728 East Broadway,completed,2017,18,6400,42.33595937,-71.03622898,Boston,Metropolitan Area Planning Council
+Beaver Country Day School - Research and Design Center,completed,2017,0,38211,42.31813356,-71.16535187,Brookline,Metropolitan Area Planning Council
+266 Beacon Street,completed,2017,7,0,42.38251453,-71.11222188,Somerville,Metropolitan Area Planning Council
+Parkside on Adams,completed,2017,43,7000,42.28580085,-71.12831346,Boston,Metropolitan Area Planning Council
+Clapp Memorial,completed,2017,21,0,42.21619117,-70.93828307,Weymouth,Metropolitan Area Planning Council
+170 West Broadway,completed,2017,33,5170,42.34054134,-71.05291357,Boston,Metropolitan Area Planning Council
+59 Temple Place,completed,2017,0,135500,42.35466941,-71.06167943,Boston,Metropolitan Area Planning Council
+Myrtle Village,completed,2017,7,0,42.34584445,-71.23560659,Newton,Metropolitan Area Planning Council
+40 Fisher Avenue,completed,2017,15,0,42.33015782,-71.10083402,Boston,Metropolitan Area Planning Council
+Dragon Court - 10 lots,completed,2017,20,0,42.5099296,-71.12576847,Woburn,Metropolitan Area Planning Council
+Seaport Square: Parcel J - Yotel Seaport Boston,completed,2017,0,99400,42.35230526,-71.04730427,Boston,Metropolitan Area Planning Council
+Clarks Hill - Neighborhood Cluster Development,completed,2017,28,0,42.28208941,-71.40344617,Framingham,Metropolitan Area Planning Council
+47 Webster,completed,2017,4,2000,42.36718989,-71.03909915,Boston,Metropolitan Area Planning Council
+Distillery Project - Phase 1,completed,2017,62,27200,42.33756169,-71.04203002,Boston,Metropolitan Area Planning Council
+621 East First Street,completed,2017,28,0,42.33791728,-71.034604,Boston,Metropolitan Area Planning Council
+Marlborough Rd ANR,completed,2017,3,0,42.51449708,-70.92558179,Salem,Metropolitan Area Planning Council
+Austin at 205 E Street,completed,2017,34,0,42.33485476,-71.05248544,Boston,Metropolitan Area Planning Council
+30 B Street,completed,2017,32,0,42.33917389,-71.05627938,Boston,Metropolitan Area Planning Council
+57 L Street,completed,2017,13,0,42.33626354,-71.03566924,Boston,Metropolitan Area Planning Council
+Wegman's Supermarket,completed,2017,0,120000,42.40706696,-71.09218089,Medford,Metropolitan Area Planning Council
+10 Farnsworth,completed,2017,9,1400,42.35100244,-71.04897651,Boston,Metropolitan Area Planning Council
+290 Highland Ave,completed,2017,7,0,42.39214852,-71.11272328,Somerville,Metropolitan Area Planning Council
+Bellevue Heights,completed,2017,28,0,42.46763958,-71.00213322,Saugus,Metropolitan Area Planning Council
+Wrentham Crossing,completed,2017,0,130000,42.03544069,-71.34489985,Wrentham,Metropolitan Area Planning Council
+Winsor School Project,completed,2017,0,110000,42.34083523,-71.10750874,Boston,Metropolitan Area Planning Council
+Harvard College Winthrop House Expansion,completed,2017,0,0,42.37047391,-71.1202593,Cambridge,Metropolitan Area Planning Council
+477-481 Harrison Avenue,completed,2017,18,0,42.3420573,-71.06670798,Boston,Metropolitan Area Planning Council
+Rutherford Landing,completed,2017,15,0,42.38085465,-71.07120489,Boston,Metropolitan Area Planning Council
+Estates at Cohasset,completed,2017,41,0,42.22666095,-70.80345297,Cohasset,Metropolitan Area Planning Council
+Maison Vernon,completed,2017,7,0,42.35852912,-71.06491888,Boston,Metropolitan Area Planning Council
+Rockwood Estates,completed,2017,9,0,42.28043821,-71.21066402,Needham,Metropolitan Area Planning Council
+Meriel Marina Bay,completed,2017,352,20000,42.2999849,-71.03119506,Quincy,Metropolitan Area Planning Council
+Dunkin Donuts,completed,2017,0,276,42.24565385,-71.28188841,Dover,Metropolitan Area Planning Council
+610 Main St (MITIMCO/Phase 2),completed,2017,0,238264,42.36250368,-71.09306592,Cambridge,Metropolitan Area Planning Council
+1047 Commonwealth Avenue,completed,2017,180,0,42.35258895,-71.12259739,Boston,Metropolitan Area Planning Council
+135 Athens Street,completed,2017,15,0,42.34077727,-71.05302163,Boston,Metropolitan Area Planning Council
+The Harlo,completed,2017,212,7025,42.34381377,-71.0994278,Boston,Metropolitan Area Planning Council
+70 Parker Hill Avenue - Sunset Lofts,completed,2017,42,0,42.33099425,-71.10918331,Boston,Metropolitan Area Planning Council
+75-83 Court Street,completed,2017,36,0,42.35354188,-71.20443782,Newton,Metropolitan Area Planning Council
+AC Hotel South End,completed,2017,0,95000,42.34490065,-71.06195866,Boston,Metropolitan Area Planning Council
+Nova Residences,completed,2017,85,0,42.34831996,-71.14252183,Boston,Metropolitan Area Planning Council
+The Parkside on Adams,completed,2017,43,7000,42.28602949,-71.1281696,Boston,Metropolitan Area Planning Council
+Boston University - 610 Commonwealth Ave (CILSE),completed,2017,0,136200,42.34893919,-71.10093162,Boston,Metropolitan Area Planning Council
+Congress Street Residences,completed,2017,64,3000,42.51651779,-70.89012645,Salem,Metropolitan Area Planning Council
+Kesseler Woods,completed,2017,88,0,42.30297828,-71.16998869,Newton,Metropolitan Area Planning Council
+Hogan Tire Center,completed,2017,0,6140,42.22825377,-71.18566475,Westwood,Metropolitan Area Planning Council
+Trac 75,completed,2017,80,2277,42.35651344,-71.13595452,Boston,Metropolitan Area Planning Council
+132 Chestnut Hill Avenue,completed,2017,61,3500,42.34290539,-71.15312404,Boston,Metropolitan Area Planning Council
+20 Sussex Street,completed,2017,4,0,42.3358233,-71.083511,Boston,Metropolitan Area Planning Council
+The Vault,completed,2017,49,3800,42.46425078,-70.94584269,Lynn,Metropolitan Area Planning Council
+16-20 Peterborough,completed,2017,20,0,42.34386287,-71.09605271,Boston,Metropolitan Area Planning Council
+Patriot Homes,completed,2017,24,0,42.33858303,-71.05081029,Boston,Metropolitan Area Planning Council
+Brigham and Women's Hospital: Building for the Future,completed,2017,0,358670,42.3356,-71.1089,Boston,Metropolitan Area Planning Council
+"Brigham and Women's Hospital: Additional ""Building of the Future"" Floor",completed,2017,0,28500,42.3355,-71.1086,Boston,Metropolitan Area Planning Council
+148-152 Dorchester Avenue Phase II,completed,2017,30,0,42.3417,-71.0569,Boston,Metropolitan Area Planning Council
+Autozone,completed,2017,0,7400,42.16673935,-71.0444357,Randolph,Metropolitan Area Planning Council
+Boston Scientific Global Distribution Center,completed,2017,0,64000,42.29337,-71.033394,Quincy,Metropolitan Area Planning Council
+555 Broad Street,completed,2017,2,1250,42.21736795,-70.93715745,Weymouth,Metropolitan Area Planning Council
+Yentile Farm Recreational Facility,completed,2017,0,182350,42.53914578,-71.16138711,Wilmington,Metropolitan Area Planning Council
+Telford 180,completed,2017,85,0,42.36368278,-71.13781251,Boston,Metropolitan Area Planning Council
+Life Time Center,completed,2017,0,286000,42.31880281,-71.18015466,Newton,Metropolitan Area Planning Council
+West of Washington,completed,2017,8,850,42.28626007,-71.07135871,Boston,Metropolitan Area Planning Council
+"35, 39, 43, 47 Frederick Street",completed,2017,33,0,42.27915384,-71.41464212,Framingham,Metropolitan Area Planning Council
+367 Neponset Ave,completed,2017,22,5500,42.28648209,-71.04516471,Boston,Metropolitan Area Planning Council
+Symphony Court,completed,2017,34,0,42.34415406,-71.08803961,Boston,Metropolitan Area Planning Council
+371-401 D Street Development,completed,2017,0,347300,42.34305719,-71.0487213,Boston,Metropolitan Area Planning Council
+Union Park Condos,completed,2017,3,0,42.3419203,-71.0705257,Boston,Metropolitan Area Planning Council
+The Serenity ,completed,2017,195,2100,42.32895141,-71.11131029,Boston,Metropolitan Area Planning Council
+245 Sumner Street,completed,2017,34,2257,42.36793904,-71.03843581,Boston,Metropolitan Area Planning Council
+1467 Tremont Street,completed,2017,18,1774,42.33202516,-71.09780656,Boston,Metropolitan Area Planning Council
+Two Wells Ave,completed,2017,0,135000,42.2958057,-71.20166043,Newton,Metropolitan Area Planning Council
+Suffolk Construction Headquarters Expansion,completed,2017,0,38000,42.32821503,-71.07027481,Boston,Metropolitan Area Planning Council
+Seaport Square: Parcel H - Our Lady of Good Voyage,completed,2017,0,6200,42.35267663,-71.04806487,Boston,Metropolitan Area Planning Council
+The Flats at 131,completed,2017,72,6500,42.546388,-70.883878,Beverly,Metropolitan Area Planning Council
+Peterborough Apartments,completed,2017,20,0,42.343999,-71.095803,Boston,Metropolitan Area Planning Council
+38-42 Hyde Park Ave,completed,2017,6,1000,42.29884845,-71.11398582,Boston,Metropolitan Area Planning Council
+Newton Nexus,completed,2017,0,142000,42.31332195,-71.21287131,Newton,Metropolitan Area Planning Council
+MetroMark Apartments (3611 Washington Street),completed,2017,283,5000,42.30272528,-71.11157799,Boston,Metropolitan Area Planning Council
+Modera Medford,completed,2017,297,0,42.40555744,-71.07340292,Medford,Metropolitan Area Planning Council
+The Residences at 1022 Hancock St,completed,2017,46,0,42.25728305,-71.00733058,Quincy,Metropolitan Area Planning Council
+Jamaica Plain Branch Library (12 Sedgwick St.),completed,2017,0,700,42.30865017,-71.11501168,Boston,Metropolitan Area Planning Council
+CommCan Medical Marijuana Facility,completed,2017,0,60000,42.15876033,-71.39547401,Medway,Metropolitan Area Planning Council
+New England Sports Center (Expansion),completed,2017,0,88000,42.36529686,-71.59628962,Marlborough,Metropolitan Area Planning Council
+APEX Center of New England,completed,2017,0,487522,42.33848196,-71.58604586,Marlborough,Metropolitan Area Planning Council
+Homewood Suites by Hilton,completed,2017,0,103000,42.39912099,-71.03923877,Chelsea,Metropolitan Area Planning Council
+593 Massachusetts Avenue,completed,2017,0,8700,42.48224504,-71.50961832,Boxborough,Metropolitan Area Planning Council
+Paddock Estates at Boxborough,completed,2017,244,0,42.48950348,-71.5383358,Boxborough,Metropolitan Area Planning Council
+408 E Eighth,completed,2017,8,0,42.33145211,-71.04476325,Boston,Metropolitan Area Planning Council
+104 Hichborn st,completed,2017,4,0,42.407333,-71.001661,Revere,Metropolitan Area Planning Council
+81 Amory,completed,2017,12,0,42.32026717,-71.09961355,Boston,Metropolitan Area Planning Council
+105A S Huntington Av,completed,2017,195,0,42.329581,-71.111328,Boston,Metropolitan Area Planning Council
+Cottages at Depot Crossing (Cheevers Path),completed,2017,9,0,42.48419619,-71.27472546,Bedford,Metropolitan Area Planning Council
+40 Fisher Ave,completed,2017,15,0,42.32740896,-71.10172637,Boston,Metropolitan Area Planning Council
+Asphalt Engineering,completed,2017,0,43560,42.13680035,-71.46514934,Medway,Metropolitan Area Planning Council
+130 Cambridgepark Drive,completed,2017,213,0,42.39366255,-71.1451089,Cambridge,Metropolitan Area Planning Council
+75 Amory Avenue (Building K Jackson Square),completed,2017,55,0,42.32115057,-71.10048837,Boston,Metropolitan Area Planning Council
+50-60 Binney St,completed,2017,0,467500,42.36489753,-71.07978919,Cambridge,Metropolitan Area Planning Council
+136 Sydney ST,completed,2017,9,0,42.316078,-71.052709,Boston,Metropolitan Area Planning Council
+Wildflower Meadow,completed,2017,200,0,42.52607624,-71.43354558,Littleton,Metropolitan Area Planning Council
+186-188 Paris ST,completed,2017,9,0,42.37434,-71.035568,Boston,Metropolitan Area Planning Council
+296 Beacon St,completed,2017,9,0,42.353097,-71.082131,Boston,Metropolitan Area Planning Council
+194 Shirley ave Revere ,completed,2017,0,7068,42.407693,-70.993587,Revere,Metropolitan Area Planning Council
+549 Beach Street                                                                                                ,completed,2017,7,0,42.409263,-70.997348,Revere,Metropolitan Area Planning Council
+728 E Broadway,completed,2017,18,0,42.336081,-71.036661,Boston,Metropolitan Area Planning Council
+The Rand at Porter/1971 Massachusetts Avenue,completed,2017,20,3925,42.39015232,-71.12043317,Cambridge,Metropolitan Area Planning Council
+Cambridgepark Dr. #88,completed,2017,0,0,42.39323126,-71.14362188,Cambridge,Metropolitan Area Planning Council
+100 Binney,completed,2017,0,358782,42.36518629,-71.08092453,Cambridge,Metropolitan Area Planning Council
+1425 Tremont St,completed,2017,40,0,42.33173096,-71.09627301,Boston,Metropolitan Area Planning Council
+16 Dyer,completed,2017,40,0,42.283557,-71.079877,Boston,Metropolitan Area Planning Council
+56 Mattapan St,completed,2017,8,0,42.27782,-71.09576,Boston,Metropolitan Area Planning Council
+Countryside Estates,completed,2017,9,0,42.05431382,-71.45089024,Franklin,Metropolitan Area Planning Council
+Flats on Savin,completed,2017,14,4650,42.31163773,-71.05335318,Boston,Metropolitan Area Planning Council
+Pier 4: Phase 2,completed,2017,0,373000,42.35202529,-71.0428019,Boston,Metropolitan Area Planning Council
+288 Marginal St,completed,2017,6,0,42.36419,-71.030832,Boston,Metropolitan Area Planning Council
+584 E Third ST,completed,2017,8,0,42.336729,-71.036559,Boston,Metropolitan Area Planning Council
+Roosevelt Drive,completed,2017,3,0,42.48774744,-71.44817456,Acton,Metropolitan Area Planning Council
+364 NEPONSET AV,completed,2017,7,0,42.287107,-71.045261,Boston,Metropolitan Area Planning Council
+First Buckeye,completed,2017,0,15000,42.11171702,-70.71050036,Marshfield,Metropolitan Area Planning Council
+37 Mercer St,completed,2017,7,0,42.332273,-71.049194,Boston,Metropolitan Area Planning Council
+CVS Pharmacy,completed,2017,0,14000,42.37165353,-71.15685755,Watertown,Metropolitan Area Planning Council
+17-19 Vinton St,completed,2017,6,0,42.330181,-71.053642,Boston,Metropolitan Area Planning Council
+711 E Second,completed,2017,7,0,42.337243,-71.03453,Boston,Metropolitan Area Planning Council
+125 Stoughton St,completed,2017,6,0,42.315117,-71.061152,Boston,Metropolitan Area Planning Council
+18 Preble St,completed,2017,16,0,42.329607,-71.056166,Boston,Metropolitan Area Planning Council
+9 Channel Center,completed,2017,0,81000,42.34527896,-71.05141493,Boston,Metropolitan Area Planning Council
+Linx Watertown,completed,2017,0,185595,42.36705071,-71.15771129,Watertown,Metropolitan Area Planning Council
+Cliveden Place,completed,2017,56,7500,42.24719414,-71.00156689,Quincy,Metropolitan Area Planning Council
+Ocean 650 - Waterfront Square,completed,2017,229,0,42.41576602,-70.98989265,Revere,Metropolitan Area Planning Council
+"1 Brookline Place, Cambridge, MA",completed,2017,86,0,42.36245015,-71.10207416,Cambridge,Metropolitan Area Planning Council
+The Four Corners-Upper Washington Project,completed,2017,35,3500,42.29991048,-71.07389664,Boston,Metropolitan Area Planning Council
+17 Court Street Renovation,completed,2017,35,0,42.35928068,-71.05835283,Boston,Metropolitan Area Planning Council
+Assembly Row: Block 6/Montaje,completed,2017,447,40000,42.39389997,-71.0784,Somerville,Metropolitan Area Planning Council
+320 Maverick St,completed,2017,33,0,42.36722529,-71.03164067,Boston,Metropolitan Area Planning Council
+315 Highland Ave,completed,2017,7,1600,42.39318552,-71.11414862,Somerville,Metropolitan Area Planning Council
+Boston East ,completed,2017,200,0,42.37286697,-71.04162508,Boston,Metropolitan Area Planning Council
+1065 Tremont Street,completed,2017,16,1000,42.3362266,-71.08639377,Boston,Metropolitan Area Planning Council
+MPIII Townhomes Renovation,completed,2017,0,0,42.33374194,-71.08585767,Boston,Metropolitan Area Planning Council
+BUMC - New Patient Transport Bridge,completed,2017,0,0,42.3340729,-71.07239216,Boston,Metropolitan Area Planning Council
+Wentworth: New Sweeney Field Athletics Complex,completed,2017,0,55000,42.33782207,-71.09403113,Boston,Metropolitan Area Planning Council
+"One Canal (Parcel 2A,B&C Bullfinch Triangle)",completed,2017,320,316300,42.36412391,-71.05901211,Boston,Metropolitan Area Planning Council
+1 Edgell Road,completed,2017,0,346222,42.30061256,-71.43422562,Framingham,Metropolitan Area Planning Council
+Village at Cook's Farm,completed,2017,55,0,42.07707776,-71.36919897,Franklin,Metropolitan Area Planning Council
+Danforth Green (PUD),completed,2017,353,0,42.33081412,-71.39347376,Framingham,Metropolitan Area Planning Council
+Public Safety Facility,completed,2017,0,42456,42.11414508,-71.18745276,Sharon,Metropolitan Area Planning Council
+Brewster Ambulance Service Headquaters - 25 Main St,completed,2017,0,30240,42.20664333,-70.95710092,Weymouth,Metropolitan Area Planning Council
+65 Grove Street (Old Ionics Building),completed,2017,0,149328,42.36969414,-71.15402853,Watertown,Metropolitan Area Planning Council
+Benjamin Studley Farm,completed,2017,9,0,42.19285425,-70.76501347,Scituate,Metropolitan Area Planning Council
+New Westwood Police Headquarters,completed,2017,0,19116,42.22798121,-71.22056641,Westwood,Metropolitan Area Planning Council
+Residences at Great Pond,completed,2017,240,0,42.20589919,-71.05022009,Randolph,Metropolitan Area Planning Council
+655 Cochituate Road,completed,2017,0,20470,42.30740356,-71.38538324,Framingham,Metropolitan Area Planning Council
+Alexan,completed,2017,242,0,42.18575358,-70.942167,Weymouth,Metropolitan Area Planning Council
+20 Taft Hill Park,completed,2017,19,0,42.28774297,-71.12826442,Boston,Metropolitan Area Planning Council
+McGrane Woods,completed,2017,7,0,42.58331808,-71.18028331,Wilmington,Metropolitan Area Planning Council
+30 Wyman St,completed,2017,36,0,42.49038286,-71.15919389,Woburn,Metropolitan Area Planning Council
+The Lucas- 136 Shawmut Ave,completed,2017,33,0,42.34588807,-71.06597621,Boston,Metropolitan Area Planning Council
+Four51 Marlborough,completed,2017,8,0,42.34994819,-71.09080263,Boston,Metropolitan Area Planning Council
+78 West Main St.,cancelled,2018,0,3000,42.21818176,-71.54066441,Hopkinton,Metropolitan Area Planning Council
+Bridge Boston Charter School,completed,2018,0,46000,42.31615865,-71.08450062,Boston,Metropolitan Area Planning Council
+201 West Brookline Street,completed,2018,9,0,42.34338867,-71.07642061,Boston,Metropolitan Area Planning Council
+2 Lewis St,completed,2018,1,0,42.41381156,-71.32602942,Lincoln,Metropolitan Area Planning Council
+"Lowe's, Walmart and Meineke Expansions",completed,2018,0,320779,42.49261773,-70.93580735,Salem,Metropolitan Area Planning Council
+"44 Maple St.,",completed,2018,10,0,42.5662717,-70.93665908,Danvers,Metropolitan Area Planning Council
+Whitney Farm,completed,2018,48,0,42.23850667,-71.41712708,Sherborn,Metropolitan Area Planning Council
+"60 Vassar Street/MIT Nano Lab, Building 12",completed,2018,0,216500,42.36066614,-71.09184747,Cambridge,Metropolitan Area Planning Council
+35 South Huntington,completed,2018,38,7080,42.33127003,-71.11203983,Boston,Metropolitan Area Planning Council
+506 Old Bedford Rd. PRD,completed,2018,8,0,42.4716543,-71.32164049,Concord,Metropolitan Area Planning Council
+Penniman on the Park,completed,2018,36,0,42.35529814,-71.13619509,Boston,Metropolitan Area Planning Council
+505 West Central Street,completed,2018,0,11760,42.09036054,-71.41905756,Franklin,Metropolitan Area Planning Council
+Concord Academy Bradford Hall,completed,2018,0,8000,42.45929628,-71.35466081,Concord,Metropolitan Area Planning Council
+Oakmont Lane Subdivision,completed,2018,4,0,42.40990786,-71.1948918,Belmont,Metropolitan Area Planning Council
+142 Pleasant St,completed,2018,16,0,42.37250132,-70.98634052,Winthrop,Metropolitan Area Planning Council
+5165 Washington Street,completed,2018,20,0,42.26240694,-71.15640149,Boston,Metropolitan Area Planning Council
+Post,completed,2018,0,430000,42.41858181,-71.25433117,Waltham,Metropolitan Area Planning Council
+115 Hartwell Ave,completed,2018,0,91000,42.46474465,-71.26462046,Lexington,Metropolitan Area Planning Council
+Archer Hotel,completed,2018,0,30000,42.48859073,-71.2231518,Burlington,Metropolitan Area Planning Council
+Sphere Luxury Apartments,completed,2018,42,3790,42.40080182,-71.11193958,Medford,Metropolitan Area Planning Council
+Woburn Boys & Girls Club,completed,2018,0,43700,42.48938384,-71.15441024,Woburn,Metropolitan Area Planning Council
+Hopkinton School Project,completed,2018,0,83250,42.21366731,-71.51259784,Hopkinton,Metropolitan Area Planning Council
+Normandy Real Estate Partners- O Firmin/Pleasant St.,completed,2018,0,155812,42.29871812,-71.49251196,Southborough,Metropolitan Area Planning Council
+270 Cochituate Rd,completed,2018,0,6500,42.30333384,-71.40261294,Framingham,Metropolitan Area Planning Council
+518 Pleasant Street,completed,2018,60,0,42.30287311,-71.45942216,Framingham,Metropolitan Area Planning Council
+Garrison Place,completed,2018,16,0,42.51627778,-71.35845538,Carlisle,Metropolitan Area Planning Council
+63-65 White Pond Rd,completed,2018,0,5000,42.42689799,-71.48217687,Stow,Metropolitan Area Planning Council
+278 Washington Street,completed,2018,4,2372,42.21420637,-70.96114066,Weymouth,Metropolitan Area Planning Council
+68 Middlesex Turnpike,completed,2018,0,3282,42.47626847,-71.21464727,Burlington,Metropolitan Area Planning Council
+Schoolhouse Commons 40B,completed,2018,20,0,42.520614,-71.11233801,Reading,Metropolitan Area Planning Council
+Regency at Stow,completed,2018,66,0,42.4548544,-71.51442963,Stow,Metropolitan Area Planning Council
+Essex Landing,completed,2018,256,100000,42.45395756,-71.02380961,Saugus,Metropolitan Area Planning Council
+295 Canal Street,completed,2018,0,55117,42.41847854,-71.0725499,Malden,Metropolitan Area Planning Council
+Pipefitters Association Local 537 New Training and Office Facility,completed,2018,0,70000,42.32364864,-71.06258063,Boston,Metropolitan Area Planning Council
+828 Winter Street,completed,2018,0,144910,42.40185717,-71.27826987,Waltham,Metropolitan Area Planning Council
+UMass Boston Residence Hall 1,completed,2018,0,0,42.31724966,-71.0413216,Boston,Metropolitan Area Planning Council
+The Residences at Fairmount Station,completed,2018,27,0,42.25478923,-71.11914543,Boston,Metropolitan Area Planning Council
+The 1850 - 88 Wareham Street,completed,2018,27,2000,42.3391084,-71.06605159,Boston,Metropolitan Area Planning Council
+1620 Tremont (Roxbury Crossing / Parcel 25),completed,2018,88,196000,42.33355538,-71.10436118,Boston,Metropolitan Area Planning Council
+Stall Brook Business Park,completed,2018,0,7400,42.12998906,-71.47091323,Bellingham,Metropolitan Area Planning Council
+Dover Estates,completed,2018,4,0,42.1785765,-71.33802184,Millis,Metropolitan Area Planning Council
+The Point at 180,completed,2018,86,0,42.42553681,-71.0630539,Malden,Metropolitan Area Planning Council
+Forestdale Park Assisted Living,completed,2018,80,0,42.4408088,-71.05490458,Malden,Metropolitan Area Planning Council
+Woodmere at Brush Hill,completed,2018,36,0,42.24294125,-71.11791908,Milton,Metropolitan Area Planning Council
+345 Harrison,completed,2018,585,40000,42.34514828,-71.0644361,Boston,Metropolitan Area Planning Council
+81 West Union Street,completed,2018,0,98600,42.25150774,-71.47245586,Ashland,Metropolitan Area Planning Council
+Reading Village 40B,completed,2018,68,0,42.52134197,-71.10753116,Reading,Metropolitan Area Planning Council
+Linden Ponds,completed,2018,1086,40000,42.19432046,-70.9140759,Hingham,Metropolitan Area Planning Council
+New England Conservatory Student Life and Performance Center,completed,2018,0,135000,42.34163532,-71.08513283,Boston,Metropolitan Area Planning Council
+Gramstorf Park Reconstruction,completed,2018,0,0,42.40780009,-71.04295632,Everett,Metropolitan Area Planning Council
+The Pioneer,completed,2018,286,2500,42.40166669,-71.04561742,Everett,Metropolitan Area Planning Council
+371 Main Street,completed,2018,24,0,42.41358828,-71.06326027,Everett,Metropolitan Area Planning Council
+Devotion School Project,completed,2018,0,178535,42.34480443,-71.12371378,Brookline,Metropolitan Area Planning Council
+John Sherman Estates,completed,2018,10,0,42.10720797,-70.72250329,Marshfield,Metropolitan Area Planning Council
+Open Meadow Realty - Crooked Lane,completed,2018,0,0,42.58483912,-70.78916939,Manchester,Metropolitan Area Planning Council
+Food Service + Retail,completed,2018,0,4764,42.16208253,-71.06070654,Randolph,Metropolitan Area Planning Council
+902 East Second Street,completed,2018,36,0,42.33765859,-71.02658442,Boston,Metropolitan Area Planning Council
+EnVision Hotel,completed,2018,0,59716,42.40191654,-71.04842011,Everett,Metropolitan Area Planning Council
+Stone Ridge Heights,completed,2018,8,0,42.44505449,-71.041149,Melrose,Metropolitan Area Planning Council
+Candy Factory,completed,2018,8,0,42.5116443,-70.89635494,Salem,Metropolitan Area Planning Council
+Dental Parking Lot,completed,2018,0,0,42.46104894,-71.06123231,Melrose,Metropolitan Area Planning Council
+10 Magnolia Ave,completed,2018,6,0,42.57832921,-70.7159589,Gloucester,Metropolitan Area Planning Council
+236-240 Salem Street,completed,2018,16,0,42.42046364,-71.09996533,Medford,Metropolitan Area Planning Council
+Century Mill Estates,completed,2018,78,0,42.41245305,-71.59949378,Bolton,Metropolitan Area Planning Council
+70 Bremen Street,completed,2018,32,1028,42.3704719,-71.03735509,Boston,Metropolitan Area Planning Council
+Tufts University Central Energy Plant,completed,2018,0,20000,42.40731864,-71.11635511,Medford,Metropolitan Area Planning Council
+121-127 Portland Street (The Forecaster Bldg),completed,2018,81,3719,42.36359439,-71.06047463,Boston,Metropolitan Area Planning Council
+The Arsenal on the Charles,completed,2018,0,263000,42.362681,-71.16604549,Watertown,Metropolitan Area Planning Council
+Woburn Homewood Suites and Hampton Inn,completed,2018,0,103684,42.5002447,-71.12385576,Woburn,Metropolitan Area Planning Council
+1868 Massachusetts Ave.,completed,2018,0,34900,42.38789207,-71.11971033,Cambridge,Metropolitan Area Planning Council
+Winthrop Hospital,completed,2018,74,0,42.37941446,-70.99097496,Winthrop,Metropolitan Area Planning Council
+67 Florence St,completed,2018,6,0,42.384528,-71.08211673,Somerville,Metropolitan Area Planning Council
+The Haven,completed,2018,3,0,42.14473355,-71.4536297,Medway,Metropolitan Area Planning Council
+107 Highland Ave,completed,2018,8,0,42.51022826,-70.90979009,Salem,Metropolitan Area Planning Council
+Whittier Place Apartments,completed,2018,29,0,42.28995738,-71.07488705,Boston,Metropolitan Area Planning Council
+50 St. Peter Street,completed,2018,36,3200,42.52432616,-70.89323936,Salem,Metropolitan Area Planning Council
+444 Somerville Ave,completed,2018,0,55700,42.38127758,-71.10228961,Somerville,Metropolitan Area Planning Council
+1072 Washington Street,completed,2018,2,1200,42.19872237,-70.93245679,Weymouth,Metropolitan Area Planning Council
+Smith House Renovation,completed,2018,0,0,42.33215144,-71.08450241,Boston,Metropolitan Area Planning Council
+529-535 Washington St,completed,2018,0,1750,42.21451038,-71.00481212,Braintree,Metropolitan Area Planning Council
+40 River Street,completed,2018,18,0,42.15928462,-70.79271791,Norwell,Metropolitan Area Planning Council
+Boulevard on the Greenway,completed,2018,36,3550,42.35738635,-71.05208331,Boston,Metropolitan Area Planning Council
+Wyllie Estates Subdivision,completed,2018,4,0,42.06975732,-71.36505346,Wrentham,Metropolitan Area Planning Council
+31 Orleans Street,completed,2018,14,0,42.36752018,-71.03821088,Boston,Metropolitan Area Planning Council
+100 & 150 Exchange Street,completed,2018,210,1951,42.42594379,-71.07089081,Malden,Metropolitan Area Planning Council
+490 Eastern Ave,completed,2018,0,43000,42.42905386,-71.05622436,Malden,Metropolitan Area Planning Council
+White Pines Estates II,completed,2018,10,0,42.18708032,-71.46041677,Holliston,Metropolitan Area Planning Council
+32 Church St,completed,2018,5,0,42.36773185,-71.1850198,Watertown,Metropolitan Area Planning Council
+150 West Broadway Street,completed,2018,24,0,42.34075925,-71.05336613,Boston,Metropolitan Area Planning Council
+Self Storage,completed,2018,0,132500,42.30557462,-71.10990759,Boston,Metropolitan Area Planning Council
+East Meadow Farm,completed,2018,21,0,42.61479672,-70.99290783,Middleton,Metropolitan Area Planning Council
+Gordon Drive,completed,2018,18,0,42.12138164,-71.49789683,Milford,Metropolitan Area Planning Council
+Modera Hopkinton/Hopkinton Mews,completed,2018,280,0,42.21428147,-71.53750354,Hopkinton,Metropolitan Area Planning Council
+39 A Street,completed,2018,23,0,42.3412206,-71.05581358,Boston,Metropolitan Area Planning Council
+Emerson College - 1-3 Boylston Place,completed,2018,0,0,42.3520418,-71.06613334,Boston,Metropolitan Area Planning Council
+Davenport Village,completed,2018,18,0,42.20279845,-71.50646658,Hopkinton,Metropolitan Area Planning Council
+231 Lowell Street,completed,2018,19,1000,42.39186994,-71.10620535,Somerville,Metropolitan Area Planning Council
+Spring Hill Farm,completed,2018,17,0,42.5918999,-70.85809548,Wenham,Metropolitan Area Planning Council
+60 Lenox Street,completed,2018,18,0,42.19346966,-71.19666429,Norwood,Metropolitan Area Planning Council
+85-93 Willow Court,completed,2018,14,0,42.32501985,-71.06423934,Boston,Metropolitan Area Planning Council
+DLTA Project 1,completed,2018,24,0,42.24282835,-71.36966615,Sherborn,Metropolitan Area Planning Council
+235 Lowell Street,completed,2018,6,0,42.392033,-71.1064237,Somerville,Metropolitan Area Planning Council
+"Black Horse Place PRD, 140 Commerford Rd",completed,2018,22,0,42.47651681,-71.40104655,Concord,Metropolitan Area Planning Council
+505-517 Concord Street,completed,2018,0,6467,42.29007906,-71.40897862,Framingham,Metropolitan Area Planning Council
+Corey10 Apartments,completed,2018,40,0,42.45224997,-71.06813483,Melrose,Metropolitan Area Planning Council
+The Aberdeen,completed,2018,40,2400,42.34171443,-71.14325795,Boston,Metropolitan Area Planning Council
+Broadway Residences,completed,2018,13,25000,42.38579447,-71.07798099,Somerville,Metropolitan Area Planning Council
+The Auerbach Center - Boston Landing,completed,2018,0,161700,42.35752217,-71.14558792,Boston,Metropolitan Area Planning Council
+Woods Memorial Bridge Replacement,completed,2018,0,0,42.40363484,-71.07187658,Everett,Metropolitan Area Planning Council
+Elevation Apartments at Crown Colony,completed,2018,492,0,42.22946682,-71.0127377,Quincy,Metropolitan Area Planning Council
+The Residences at Vinnin Square,completed,2018,84,0,42.420275,-71.100789,Medford,Metropolitan Area Planning Council
+9 Williams Street,completed,2018,30,7000,42.332294,-71.081787,Boston,Metropolitan Area Planning Council
+Lantera,completed,2018,295,16400,42.3562685,-71.14296769,Boston,Metropolitan Area Planning Council
+242 Spencer Avenue,completed,2018,34,0,42.400777,-71.020235,Chelsea,Metropolitan Area Planning Council
+100 Federal Street Atrium Addition,completed,2018,0,9000,42.354787,-71.056131,Boston,Metropolitan Area Planning Council
+The Pierce,completed,2018,349,20500,42.34366597,-71.10193189,Boston,Metropolitan Area Planning Council
+Boston College Field House,completed,2018,0,115700,42.33576733,-71.14985888,Boston,Metropolitan Area Planning Council
+14 West Broadway,completed,2018,47,11151,42.34297942,-71.0568354,Boston,Metropolitan Area Planning Council
+CATS Academy,completed,2018,0,100000,42.17221135,-71.01317734,Braintree,Metropolitan Area Planning Council
+375-399 Chestnut Hill Ave - Cleveland Circle Cinema,completed,2018,92,123030,42.33505832,-71.15065114,Boston,Metropolitan Area Planning Council
+Boston Preparatory Charter Public School - Middle and High School,completed,2018,40,48800,42.26220878,-71.11010848,Boston,Metropolitan Area Planning Council
+Mass General Ambulatory Care Facility,completed,2018,0,640000,42.36133658,-71.069752,Boston,Metropolitan Area Planning Council
+111 Washington St Office Building,completed,2018,0,19495,42.25021625,-70.99897384,Quincy,Metropolitan Area Planning Council
+Harvard University (Allston): HBS Burden Hall,completed,2018,0,105000,42.36490263,-71.12094769,Boston,Metropolitan Area Planning Council
+145 Newbury Avenue,completed,2018,18,0,42.2788452,-71.02787117,Quincy,Metropolitan Area Planning Council
+Joseph M Smith Community Health Center,completed,2018,0,48000,42.36217826,-71.14408226,Boston,Metropolitan Area Planning Council
+Holiday Inn Boston Logan Airport- Chelsea,completed,2018,0,40300,42.40313183,-71.01895546,Chelsea,Metropolitan Area Planning Council
+"13-15, 17 Fifth Street",completed,2018,12,0,42.39324477,-71.03454585,Chelsea,Metropolitan Area Planning Council
+Tri Valley Commons,completed,2018,0,13412,42.15216128,-71.41118852,Medway,Metropolitan Area Planning Council
+112-114 Rantoul St (Holmes Beverly),completed,2018,67,5188,42.54554471,-70.88490408,Beverly,Metropolitan Area Planning Council
+Apex Chimney Company Inc.,completed,2018,0,100,42.60487299,-71.02873284,Middleton,Metropolitan Area Planning Council
+40 Malvern Street,completed,2018,48,0,42.3540906,-71.12503458,Boston,Metropolitan Area Planning Council
+Forbes Crossing,completed,2018,0,148130,42.0361543,-71.23341288,Foxborough,Metropolitan Area Planning Council
+North Meadows Village,completed,2018,42,0,42.61345232,-71.03968562,Middleton,Metropolitan Area Planning Council
+Lumen Charlestown (30 Polk Street),completed,2018,30,0,42.37959812,-71.06113258,Boston,Metropolitan Area Planning Council
+Cumberland Farms,completed,2018,0,100,42.59464041,-71.01488631,Middleton,Metropolitan Area Planning Council
+Port 45,completed,2018,105,3400,42.34205484,-71.05429042,Boston,Metropolitan Area Planning Council
+Ohlson Way Subdivision,completed,2018,5,0,42.6045652,-70.98979678,Middleton,Metropolitan Area Planning Council
+Marlborough Hills,completed,2018,350,1205410,42.32925865,-71.58068861,Marlborough,Metropolitan Area Planning Council
+480 Rantoul,completed,2018,90,1900,42.55636586,-70.88133951,Beverly,Metropolitan Area Planning Council
+44 and 52 Standley OSRD (Emily Way),completed,2018,8,0,42.5711174,-70.84762466,Beverly,Metropolitan Area Planning Council
+122 Cross Lane OSRD (Greening Way),completed,2018,3,0,42.56266808,-70.85328155,Beverly,Metropolitan Area Planning Council
+50 and 54 Boyles Street OSRD (Village Lane),completed,2018,6,0,42.56029132,-70.85223538,Beverly,Metropolitan Area Planning Council
+Fairview Estates,completed,2018,127,0,42.23720798,-71.49342175,Hopkinton,Metropolitan Area Planning Council
+Legacy Farms South Villages (Pulte),completed,2018,275,0,42.23264546,-71.49404383,Hopkinton,Metropolitan Area Planning Council
+Centerboard,completed,2018,15,0,42.47409868,-71.06104553,Melrose,Metropolitan Area Planning Council
+8 Mechanic Street,completed,2018,3,2130,42.06581385,-71.2493397,Foxborough,Metropolitan Area Planning Council
+80-84 Cambridgepark Drive,completed,2018,254,1800,42.39311872,-71.14248984,Cambridge,Metropolitan Area Planning Council
+Hanover Foxborough,completed,2018,248,0,42.03909372,-71.24330686,Foxborough,Metropolitan Area Planning Council
+Moderna Therapeutics ,completed,2018,0,200000,42.20759118,-71.20128469,Norwood,Metropolitan Area Planning Council
+887 Massachusetts Ave,completed,2018,4,2477,42.41759012,-71.16363879,Arlington,Metropolitan Area Planning Council
+The Winnisimmet Lounge by Ciao! Pizza and Pasta,completed,2018,4,2600,42.3880753,-71.0396722,Chelsea,Metropolitan Area Planning Council
+KROHNE,completed,2018,0,0,42.57871857,-70.91185126,Beverly,Metropolitan Area Planning Council
+Crosby Corporate Center upgrade,completed,2018,0,0,42.50841557,-71.24506631,Bedford,Metropolitan Area Planning Council
+21 Summit Ave.,completed,2018,4,0,42.54277608,-70.88610165,Beverly,Metropolitan Area Planning Council
+Harvard University: 79 JFK St. - Kennedy School Expansion,completed,2018,0,76862,42.37158721,-71.12204303,Cambridge,Metropolitan Area Planning Council
+Proto Apartments,completed,2018,280,16000,42.36334225,-71.08779636,Cambridge,Metropolitan Area Planning Council
+Former convent ,completed,2018,6,0,42.52361761,-70.8920639,Salem,Metropolitan Area Planning Council
+PBX Residences,completed,2018,46,0,42.35228071,-71.06101822,Boston,Metropolitan Area Planning Council
+1336-1362 Massachusetts Avenue/Smith Campus Center,completed,2018,0,95000,42.37282689,-71.11865356,Cambridge,Metropolitan Area Planning Council
+262 Monsignor O'Brien Highway/The Ivy Residences,completed,2018,55,0,42.37333255,-71.08193777,Cambridge,Metropolitan Area Planning Council
+509 E First,completed,2018,8,0,42.337985,-71.039269,Boston,Metropolitan Area Planning Council
+48 Boylston Street,completed,2018,46,14765,42.35216864,-71.06407061,Boston,Metropolitan Area Planning Council
+126 Salem St,completed,2018,9,0,42.364932,-71.055575,Boston,Metropolitan Area Planning Council
+17 Walden ST ,completed,2018,7,0,42.40820404,-70.9949433,Revere,Metropolitan Area Planning Council
+2 Leighton Street/5 Glassworks Avenue Phase 2 (Avalon Bay),completed,2018,265,5000,42.37041062,-71.07423148,Cambridge,Metropolitan Area Planning Council
+Umass Boston West Garage,completed,2018,0,0,42.31524853,-71.04147641,Boston,Metropolitan Area Planning Council
+375-385 Chestnut Hill Av,completed,2018,92,0,42.334694,-71.150615,Boston,Metropolitan Area Planning Council
+3383-3389 Washington Street,completed,2018,21,2373,42.30869195,-71.10561312,Boston,Metropolitan Area Planning Council
+143 Village Street,completed,2018,3,0,42.139993,-71.397296,Medway,Metropolitan Area Planning Council
+8 ENTERPRISE,completed,2018,9,0,42.323013,-71.061433,Boston,Metropolitan Area Planning Council
+891 E FIRST,completed,2018,5,0,42.338186,-71.027667,Boston,Metropolitan Area Planning Council
+"17 Trotter Drive, Medway, Massachusetts 02053",completed,2018,0,1,42.14100238,-71.47137184,Medway,Metropolitan Area Planning Council
+7 BAKER CT,completed,2018,8,0,42.32505147,-71.0634034,Boston,Metropolitan Area Planning Council
+Willard Square at Linden Ponds,completed,2018,104,0,42.19609926,-70.91445781,Hingham,Metropolitan Area Planning Council
+Gateway North,completed,2018,71,4000,42.46235463,-70.94241112,Lynn,Metropolitan Area Planning Council
+Union Point -- Mastlight,completed,2018,278,14000,42.15477853,-70.94591976,Weymouth,Metropolitan Area Planning Council
+1119-1133 Broadway,completed,2018,8,0,42.403216,-71.126631,Somerville,Metropolitan Area Planning Council
+38-42 Medford Street,completed,2018,7,0,42.37448748,-71.0884332,Somerville,Metropolitan Area Planning Council
+116 Holland Street,completed,2018,4,0,42.39932151,-71.12512746,Somerville,Metropolitan Area Planning Council
+74 Lancaster Street,completed,2018,3,0,42.24805808,-70.98967839,Quincy,Metropolitan Area Planning Council
+Michael Road,completed,2018,7,0,42.36520653,-71.34885311,Wayland,Metropolitan Area Planning Council
+Holiday Inn Express Boston,completed,2018,0,37325,42.32747572,-71.05953756,Boston,Metropolitan Area Planning Council
+The Watson,completed,2018,140,0,42.24037301,-70.97858591,Quincy,Metropolitan Area Planning Council
+150 Quincy Avenue,completed,2018,17,0,42.24263968,-70.99434846,Quincy,Metropolitan Area Planning Council
+56 Albertina Street,completed,2018,4,0,42.23616518,-71.01632477,Quincy,Metropolitan Area Planning Council
+Emerson College - Little Building Project,completed,2018,0,0,42.35207606,-71.0649015,Boston,Metropolitan Area Planning Council
+Assembly Row: Block 5A,completed,2018,132,134000,42.39350832,-71.0793407,Somerville,Metropolitan Area Planning Council
+Portside at Pier 1  Shipyard and Marina- Phase II,completed,2018,296,0,42.36477326,-71.04071771,Boston,Metropolitan Area Planning Council
+Medical Marijuana Dispensary,completed,2018,0,4294,42.38720919,-71.08110046,Somerville,Metropolitan Area Planning Council
+39 Murdock St,completed,2018,3,0,42.39520188,-71.10852505,Somerville,Metropolitan Area Planning Council
+Coppersmith Village Development,completed,2018,71,3000,42.37365913,-71.0409309,Boston,Metropolitan Area Planning Council
+Washington Place Condo,completed,2018,24,0,42.43026219,-71.02324939,Revere,Metropolitan Area Planning Council
+Neighborhood Pace,completed,2018,0,15500,42.42066153,-70.99916102,Revere,Metropolitan Area Planning Council
+Northeastern University - Interdisciplinary Science & Engineering Ctr,completed,2018,0,197000,42.33769049,-71.08699047,Boston,Metropolitan Area Planning Council
+35 Northampton Street,completed,2018,245,0,42.33419178,-71.07509518,Boston,Metropolitan Area Planning Council
+50 Liberty,completed,2018,120,0,42.35426911,-71.04447187,Boston,Metropolitan Area Planning Council
+29 Massachusetts Ave,completed,2018,0,10000,42.40248578,-71.13621209,Arlington,Metropolitan Area Planning Council
+1580 River Street,completed,2018,32,0,42.24794176,-71.13188603,Boston,Metropolitan Area Planning Council
+Bentley Multipurpose Arena,completed,2018,0,75000,42.38483743,-71.22070988,Waltham,Metropolitan Area Planning Council
+Needham Mews,completed,2018,266,0,42.28459054,-71.20727519,Needham,Metropolitan Area Planning Council
+Mill and Main,completed,2018,0,1100000,42.43122458,-71.4558055,Maynard,Metropolitan Area Planning Council
+Durkee Farm Estates,completed,2018,28,0,42.51908064,-71.49832562,Littleton,Metropolitan Area Planning Council
+22 Boston Wharf Road,completed,2018,0,112807,42.35028906,-71.04701493,Boston,Metropolitan Area Planning Council
+Drumlin Farm Wildlife Sanctuary Environmental Learning Center,completed,2018,0,3700,42.40799472,-71.32966655,Lincoln,Metropolitan Area Planning Council
+The Boston Garden - The Hub at Causeway - Phase I,completed,2018,0,0,42.36580131,-71.06124672,Boston,Metropolitan Area Planning Council
+Boston College - Recreation Center,completed,2018,0,240000,42.33650311,-71.16677847,Boston,Metropolitan Area Planning Council
+Homewood Suites Needham,completed,2018,0,106896,42.30073994,-71.22151123,Needham,Metropolitan Area Planning Council
+28 Austin St,completed,2018,68,5000,42.3501831,-71.20814805,Newton,Metropolitan Area Planning Council
+The Beverly - Parcel 1B,completed,2018,239,10000,42.36542022,-71.05905634,Boston,Metropolitan Area Planning Council
+244 Hanover Street,completed,2018,9,0,42.36350349,-71.05525772,Boston,Metropolitan Area Planning Council
+54 Eastern Avenue,completed,2018,14,6000,42.42427217,-71.06599275,Malden,Metropolitan Area Planning Council
+The District Burlington,completed,2018,0,240000,42.48114018,-71.20795496,Burlington,Metropolitan Area Planning Council
+Miles River Estates,completed,2018,2,0,42.59164845,-70.84071605,Wenham,Metropolitan Area Planning Council
+Artists for Humanity Expansion,in_construction,2018,0,30000,42.34302287,-71.05360023,Boston,Metropolitan Area Planning Council
+1300 Edgell Road,in_construction,2018,0,11755,42.34732126,-71.44298175,Framingham,Metropolitan Area Planning Council
+Millbrook Tarry,in_construction,2018,0,15000,42.46247606,-71.35196371,Concord,Metropolitan Area Planning Council
+Weston Woods,in_construction,2018,280,0,42.08289279,-71.44850336,Franklin,Metropolitan Area Planning Council
+Elm Street Village,in_construction,2018,12,0,42.5757856,-70.77309558,Manchester,Metropolitan Area Planning Council
+Brandeis University New Residence Hall,in_construction,2018,0,53000,42.365666,-71.262572,Waltham,Metropolitan Area Planning Council
+82 North Main Street,in_construction,2018,0,5030,42.59991612,-71.02257569,Middleton,Metropolitan Area Planning Council
+221 So. Main Street,in_construction,2018,0,100,42.57882811,-71.00062791,Middleton,Metropolitan Area Planning Council
+156 South Main Street Solar Installation,in_construction,2018,0,100,42.58194116,-70.99673433,Middleton,Metropolitan Area Planning Council
+18 Village Road,in_construction,2018,8,0,42.60322501,-70.9759585,Middleton,Metropolitan Area Planning Council
+Box Mill Road,in_construction,2018,3,0,42.22073275,-71.52041253,Hopkinton,Metropolitan Area Planning Council
+Golden Pond Assisted Living,in_construction,2018,54,0,42.22015005,-71.53814863,Hopkinton,Metropolitan Area Planning Council
+Green Street Power Partners - Solar Array,in_construction,2018,0,0,42.47450115,-71.5509637,Boxborough,Metropolitan Area Planning Council
+Essex County Brewery,in_construction,2018,0,2000,42.5415733,-70.92388818,Peabody,Metropolitan Area Planning Council
+Granite Coast Brewery,in_construction,2018,0,5200,42.5243523,-70.92424624,Peabody,Metropolitan Area Planning Council
+TD Bank,in_construction,2018,0,2500,42.19310558,-71.19671945,Norwood,Metropolitan Area Planning Council
+87-89 Broadway,in_construction,2018,3,1210,42.40956211,-71.13882824,Arlington,Metropolitan Area Planning Council
+Amsden Building - 101 Concord Street,in_construction,2018,24,0,42.27863942,-71.4160921,Framingham,Metropolitan Area Planning Council
+Modera Framingham,in_construction,2018,270,0,42.27705432,-71.41089738,Framingham,Metropolitan Area Planning Council
+121 Seaport,in_construction,2018,0,450000,42.35092417,-71.04459426,Boston,Metropolitan Area Planning Council
+Ironwood Apartments,in_construction,2018,100,0,42.46551064,-70.99109243,Lynn,Metropolitan Area Planning Council
+Exxex Woods Estates,in_construction,2018,9,0,42.61472927,-71.02954269,Middleton,Metropolitan Area Planning Council
+Emmanuel College- New Julie Hall,in_construction,2018,0,0,42.34095547,-71.10443432,Boston,Metropolitan Area Planning Council
+Boston Children's Hospital - Pedestrian Connector,planning,2018,0,3250,42.33748925,-71.10496443,Boston,Metropolitan Area Planning Council
+37-41 East Central Street,planning,2018,6,23040,42.08273377,-71.39528575,Franklin,Metropolitan Area Planning Council
+661 and 673 Concord Street,planning,2018,8,0,42.29564929,-71.40842882,Framingham,Metropolitan Area Planning Council
+DLTA Project 2,planning,2018,17,0,42.24301327,-71.36997811,Sherborn,Metropolitan Area Planning Council
+827 Chief Justice Cushing Highway,planning,2018,0,1175,42.21869985,-70.79880236,Cohasset,Metropolitan Area Planning Council
+Tesla,planning,2018,0,26494,42.54111984,-70.94092995,Peabody,Metropolitan Area Planning Council
+11 Main Street,projected,2018,0,2398,42.29898187,-71.4341234,Framingham,Metropolitan Area Planning Council
+Greenbush Station,projected,2018,54,11800,42.17842787,-70.74461373,Scituate,Metropolitan Area Planning Council
+Avida Bank - 222 & 236 Cochituate Road,projected,2018,0,5313,42.30221006,-71.40482503,Framingham,Metropolitan Area Planning Council
+The Clarion at 311 Blue Hill Avenue,completed,2019,39,6160,42.31352865,-71.0792506,Boston,Metropolitan Area Planning Council
+Lincoln Building,completed,2019,6,4000,42.24209495,-70.88960785,Hingham,Metropolitan Area Planning Council
+110 Savin Hill Ave,completed,2019,9,10574,42.31179863,-71.05372063,Boston,Metropolitan Area Planning Council
+pizza&,completed,2019,0,100,42.37357879,-71.11971955,Cambridge,Metropolitan Area Planning Council
+206 West Broadway,completed,2019,16,1000,42.34022899,-71.05259873,Boston,Metropolitan Area Planning Council
+Walker Park Apartments - 80 Walnut Park,completed,2019,17,0,42.31463529,-71.09447988,Boston,Metropolitan Area Planning Council
+Minuteman Airfield,completed,2019,0,5000,42.4617605,-71.51693511,Stow,Metropolitan Area Planning Council
+300 Kenrick,completed,2019,1,0,42.34641584,-71.17609647,Newton,Metropolitan Area Planning Council
+13 Shetland Street,completed,2019,57,0,42.32492866,-71.06803063,Boston,Metropolitan Area Planning Council
+Brio Hingham,completed,2019,77,0,42.25112583,-70.92361727,Hingham,Metropolitan Area Planning Council
+Willow Lane,completed,2019,4,0,42.52300247,-71.28930198,Bedford,Metropolitan Area Planning Council
+Moxy Hotel,completed,2019,0,143000,42.35089322,-71.06456666,Boston,Metropolitan Area Planning Council
+160 High Street,completed,2019,0,427500,42.09847614,-71.45291223,Bellingham,Metropolitan Area Planning Council
+Alewife Research Center,completed,2019,0,184500,42.39513882,-71.14345732,Cambridge,Metropolitan Area Planning Council
+123 Hamilton St,completed,2019,52,0,42.30665412,-71.06813736,Boston,Metropolitan Area Planning Council
+Landmark Pointe,completed,2019,66,0,42.12850215,-71.23146861,Sharon,Metropolitan Area Planning Council
+Triple 9 Hillside,completed,2019,60,0,42.25691683,-71.00938853,Quincy,Metropolitan Area Planning Council
+Encore Boston Harbor,completed,2019,0,510000,42.39539423,-71.06921014,Everett,Metropolitan Area Planning Council
+429 Cherry Street,completed,2019,13,996,42.35096875,-71.22943738,Newton,Metropolitan Area Planning Council
+31 North Beacon,completed,2019,20,2170,42.35398143,-71.13874142,Boston,Metropolitan Area Planning Council
+Oak Row Apartments,completed,2019,80,0,42.27817753,-71.17232115,Boston,Metropolitan Area Planning Council
+933 East Second Street Residential Project,completed,2019,20,0,42.33724059,-71.0258641,Boston,Metropolitan Area Planning Council
+57 Quincy Shore Drive,completed,2019,28,0,42.28241041,-71.03336281,Quincy,Metropolitan Area Planning Council
+One Dalton-Four Seasons,completed,2019,180,0,42.34576238,-71.08401218,Boston,Metropolitan Area Planning Council
+ Milway Auto,completed,2019,0,1,42.13760121,-71.47816831,Medway,Metropolitan Area Planning Council
+Salem Harbor Station Redevelopment,completed,2019,0,115000,42.52487399,-70.87823419,Salem,Metropolitan Area Planning Council
+129-131 Sumner Street,completed,2019,7,0,42.24717967,-70.9866236,Quincy,Metropolitan Area Planning Council
+410 West Broadway,completed,2019,24,3200,42.33723675,-71.04777071,Boston,Metropolitan Area Planning Council
+40 Warren Street,completed,2019,14,0,42.37325505,-71.06151131,Boston,Metropolitan Area Planning Council
+3200 Washington Street,completed,2019,76,4500,42.31274237,-71.10093607,Boston,Metropolitan Area Planning Council
+2-8 New York Avenue,completed,2019,0,69539,42.29993024,-71.48357651,Framingham,Metropolitan Area Planning Council
+Arlington House,completed,2019,5,0,42.34955582,-71.06947726,Boston,Metropolitan Area Planning Council
+232 Old Colony Ave,completed,2019,24,2881,42.33216579,-71.0532591,Boston,Metropolitan Area Planning Council
+171-172 Tremont Street,completed,2019,0,17752,42.35345584,-71.06395088,Boston,Metropolitan Area Planning Council
+24-26 Hichborn Street,completed,2019,20,1774,42.35576102,-71.14395,Boston,Metropolitan Area Planning Council
+16 Boardman St,completed,2019,19,0,42.38745093,-71.00883664,Boston,Metropolitan Area Planning Council
+Maplewood School,completed,2019,12,0,42.62198205,-70.66937624,Gloucester,Metropolitan Area Planning Council
+Boston Volvo Village Redevelopment,completed,2019,0,71000,42.35466964,-71.14149863,Boston,Metropolitan Area Planning Council
+Davis 353,completed,2019,29,8300,42.3939358,-71.1195847,Somerville,Metropolitan Area Planning Council
+W. Ave at 530 Western Avenue,completed,2019,132,5000,42.36137503,-71.14539644,Boston,Metropolitan Area Planning Council
+Malden Center Redevelopment - Jefferson at Malden Center,completed,2019,320,22500,42.42704454,-71.07291429,Malden,Metropolitan Area Planning Council
+Nova Residences of Quincy,completed,2019,171,15000,42.248138,-71.001223,Quincy,Metropolitan Area Planning Council
+500 Ocean Avenue,completed,2019,305,1000,42.41301571,-70.99014436,Revere,Metropolitan Area Planning Council
+The Graphic,completed,2019,171,5000,42.38353069,-71.07444667,Boston,Metropolitan Area Planning Council
+1943 Dorchester Avenue,completed,2019,64,2100,42.28439023,-71.06520667,Boston,Metropolitan Area Planning Council
+Harvard College Lowell House Expansion,completed,2019,0,0,42.37058153,-71.11834288,Cambridge,Metropolitan Area Planning Council
+40 Acorn Park (Garage B),completed,2019,0,141745,42.39849582,-71.14753765,Cambridge,Metropolitan Area Planning Council
+212-214 Market St,completed,2019,29,1045,42.35517248,-71.14937245,Boston,Metropolitan Area Planning Council
+Cambria Hotel at Six West Broadway,completed,2019,0,87000,42.34331527,-71.0570014,Boston,Metropolitan Area Planning Council
+45 L Street,completed,2019,30,1009,42.33599067,-71.0417781,Boston,Metropolitan Area Planning Council
+Boston Landing,completed,2019,0,1430000,42.35711614,-71.14268125,Boston,Metropolitan Area Planning Council
+70 Prospect Street,completed,2019,14,1296,42.37628277,-71.09581876,Somerville,Metropolitan Area Planning Council
+Northeastern University Columbus Avenue Student Housing - Lightview,completed,2019,0,3000,42.33754488,-71.08523089,Boston,Metropolitan Area Planning Council
+1 Beachmont,completed,2019,195,0,42.39999805,-70.9936128,Revere,Metropolitan Area Planning Council
+"Garden Remedies, Inc. ",completed,2019,0,5000,42.44507578,-71.02866842,Melrose,Metropolitan Area Planning Council
+Harvard ArtLab,completed,2019,0,9000,42.36363018,-71.12872983,Boston,Metropolitan Area Planning Council
+87 Parker Street,completed,2019,12,0,42.39641884,-71.026634,Chelsea,Metropolitan Area Planning Council
+213 Broadway ,completed,2019,4,0,42.40669,-71.014134,Revere,Metropolitan Area Planning Council
+133-135 Hancock Street,completed,2019,21,0,42.28004424,-71.03418977,Quincy,Metropolitan Area Planning Council
+Hancock Lot Public Garage,completed,2019,0,0,42.24821616,-71.00005956,Quincy,Metropolitan Area Planning Council
+The Residences at 100 A Street,completed,2019,9,536,42.34282145,-71.05468024,Boston,Metropolitan Area Planning Council
+140 Pearl Street,completed,2019,19,6037,42.39038718,-71.03671545,Chelsea,Metropolitan Area Planning Council
+Blueberry Hill Townhouses,completed,2019,19,0,42.44254745,-71.05581173,Melrose,Metropolitan Area Planning Council
+North Shore Crossing,completed,2019,0,68000,42.57341681,-70.87895041,Beverly,Metropolitan Area Planning Council
+Siena at Ink Block,completed,2019,76,0,42.34432956,-71.06238762,Boston,Metropolitan Area Planning Council
+5 Florence av,completed,2019,6,0,42.405352,-70.996406,Revere,Metropolitan Area Planning Council
+61 Heath Street,completed,2019,47,0,42.326217,-71.10001261,Boston,Metropolitan Area Planning Council
+Hood Park - 480 Rutherford Avenue,completed,2019,177,10500,42.381059,-71.073085,Boston,Metropolitan Area Planning Council
+Walker Park Apartments - 67 Walnut Park,completed,2019,32,0,42.31467404,-71.09554047,Boston,Metropolitan Area Planning Council
+85 First Street/First Street Assemblage,completed,2019,0,9800,42.36816992,-71.07784803,Cambridge,Metropolitan Area Planning Council
+1699 Massachusetts Avenue,completed,2019,17,1638,42.38306503,-71.11909813,Cambridge,Metropolitan Area Planning Council
+5 Columbia Street/Mass & Main,completed,2019,60,0,42.36405005,-71.09976462,Cambridge,Metropolitan Area Planning Council
+47 Bishop Allen Drive/Mass & Main,completed,2019,23,0,42.36470679,-71.09992466,Cambridge,Metropolitan Area Planning Council
+121 First Street/First Street Assemblage,completed,2019,0,56800,42.36704024,-71.07805317,Cambridge,Metropolitan Area Planning Council
+145 Broadway/Akamai HQ,completed,2019,0,453700,42.36495659,-71.08881229,Cambridge,Metropolitan Area Planning Council
+222 Jacobs Street/Cambridge Crossing Building J/K,completed,2019,0,371400,42.37243163,-71.07456827,Cambridge,Metropolitan Area Planning Council
+Boston Crossing,completed,2019,14,0,42.522435,-70.918875,Salem,Metropolitan Area Planning Council
+Harbor & Lafayette Homes,completed,2019,27,0,42.518086,-70.893427,Salem,Metropolitan Area Planning Council
+Pier 4: Phase 3,completed,2019,100,17000,42.35306518,-71.04177975,Boston,Metropolitan Area Planning Council
+Phytotherapy Marijuana Facility,completed,2019,0,2,42.15183,-71.408809,Medway,Metropolitan Area Planning Council
+"67-71 North Street, 67-71 North Street",completed,2019,16,0,42.18899548,-71.30744585,Medfield,Metropolitan Area Planning Council
+146 -148 Village Street,completed,2019,1,0,42.14035742,-71.39749783,Medway,Metropolitan Area Planning Council
+South Bay Town Center,completed,2019,475,270000,42.32560504,-71.06237667,Boston,Metropolitan Area Planning Council
+Village Estates,completed,2019,2,0,42.139881,-71.415686,Medway,Metropolitan Area Planning Council
+92-96 Prospect Street,completed,2019,12,0,42.37536932,-71.09602008,Somerville,Metropolitan Area Planning Council
+315 Broadway,completed,2019,46,0,42.39289705,-71.09342654,Somerville,Metropolitan Area Planning Council
+The Chase at Overlook Ridge,completed,2019,2,150,42.43968928,-71.02288137,Malden,Metropolitan Area Planning Council
+10 Essex St.,completed,2019,46,4014,42.3654245,-71.10251022,Cambridge,Metropolitan Area Planning Council
+850 Cambridge Street/King Open School Complex,completed,2019,0,233862,42.3718043,-71.09091944,Cambridge,Metropolitan Area Planning Council
+Brookview House III,completed,2019,12,4228,42.28832717,-71.09190397,Boston,Metropolitan Area Planning Council
+24-28 Hurd Street,completed,2019,4,0,42.45299057,-71.07048541,Melrose,Metropolitan Area Planning Council
+Toils End Farm Open Space Subdivision,completed,2019,83,0,42.09159691,-71.34005696,Norfolk,Metropolitan Area Planning Council
+1327 Main Street,completed,2019,0,5335,42.13509325,-71.2608136,Walpole,Metropolitan Area Planning Council
+479 Washington Strip Mall,completed,2019,0,28000,42.24760736,-70.98234258,Quincy,Metropolitan Area Planning Council
+11 Education Circle/EF Building 3/Hult House,completed,2019,148,228400,42.37116744,-71.07105308,Cambridge,Metropolitan Area Planning Council
+253 Walden Street,completed,2019,27,1549,42.38627701,-71.13136087,Cambridge,Metropolitan Area Planning Council
+260 Beacon St,completed,2019,17,0,42.3823953,-71.11187684,Somerville,Metropolitan Area Planning Council
+32 Johnson Ave,completed,2019,18,0,42.25443549,-71.00476437,Quincy,Metropolitan Area Planning Council
+400-406 Mystic Ave,completed,2019,27,3000,42.39463939,-71.08832741,Somerville,Metropolitan Area Planning Council
+The Commons at Prospect Hill,completed,2019,48,15000,42.38275363,-71.09144357,Somerville,Metropolitan Area Planning Council
+Beach House,completed,2019,234,0,42.43035421,-70.97814865,Revere,Metropolitan Area Planning Council
+43 Nahant Ave,completed,2019,35,1500,42.40770715,-70.99617701,Revere,Metropolitan Area Planning Council
+9 Dehon,completed,2019,6,0,42.40689465,-70.99340128,Revere,Metropolitan Area Planning Council
+17 Dehon ,completed,2019,9,2161,42.40698848,-70.9937032,Revere,Metropolitan Area Planning Council
+1064 North Shore Road,completed,2019,13,0,42.41974444,-70.99003248,Revere,Metropolitan Area Planning Council
+Madison Melnea Cass Apartments,completed,2019,76,0,42.33468929,-71.08527194,Boston,Metropolitan Area Planning Council
+Bartlett Station Condos (Bartlett E),completed,2019,16,0,42.32653698,-71.08835915,Boston,Metropolitan Area Planning Council
+Bartlett Yards (Building B),completed,2019,60,13343,42.32675361,-71.08778916,Boston,Metropolitan Area Planning Council
+Melnea Hotel and Residences,completed,2019,50,84000,42.33342503,-71.08104514,Boston,Metropolitan Area Planning Council
+1004-1012 Tremont Street,completed,2019,7,2224,42.33675128,-71.08471296,Boston,Metropolitan Area Planning Council
+"1065 Tremont Street, Phase II",completed,2019,28,0,42.33638161,-71.08655731,Boston,Metropolitan Area Planning Council
+20 Sidney Street/STAR Market Office Conversion,completed,2019,0,31365,42.36180052,-71.10008743,Cambridge,Metropolitan Area Planning Council
+Douglass Park,completed,2019,44,0,42.33868523,-71.08292166,Boston,Metropolitan Area Planning Council
+Dewitt Community Center,completed,2019,0,21374,42.33291966,-71.08451392,Boston,Metropolitan Area Planning Council
+30 Acorn Park (400 Discovery Park),completed,2019,0,127000,42.39848448,-71.14744165,Cambridge,Metropolitan Area Planning Council
+Town Line Estates,completed,2019,2,0,42.13716507,-71.38942975,Medway,Metropolitan Area Planning Council
+Wollaston Station Renovation,completed,2019,0,0,42.26678537,-71.02035714,Quincy,Metropolitan Area Planning Council
+735 Truman Parkway,completed,2019,46,0,42.25165586,-71.12058946,Boston,Metropolitan Area Planning Council
+Bradford Development,completed,2019,115,37500,42.38056639,-71.17509766,Belmont,Metropolitan Area Planning Council
+Aura at Weymouth,completed,2019,24,0,42.19036267,-70.94972342,Weymouth,Metropolitan Area Planning Council
+JFK Crossing,completed,2019,25,5700,42.34542897,-71.12745084,Brookline,Metropolitan Area Planning Council
+Former Flynntan,in_construction,2019,55,1184,42.51996087,-70.91039445,Salem,Metropolitan Area Planning Council
+881 Massachusetts Avenue,in_construction,2019,0,6500,42.48345849,-71.52172629,Boxborough,Metropolitan Area Planning Council
+Evergreen Meadows,in_construction,2019,17,0,42.4769133,-71.26541303,Bedford,Metropolitan Area Planning Council
+Irene Road,in_construction,2019,4,0,42.50284527,-71.27778376,Bedford,Metropolitan Area Planning Council
+Concord Museum Expansion,in_construction,2019,0,13000,42.45771283,-71.34226361,Concord,Metropolitan Area Planning Council
+2nd Avenue Residences,in_construction,2019,390,0,42.30259369,-71.21628443,Needham,Metropolitan Area Planning Council
+875 Hale Street,in_construction,2019,5,0,42.56369276,-70.80529874,Beverly,Metropolitan Area Planning Council
+Rail Transit Development Cirrus Apartments,in_construction,2019,398,0,42.25916036,-71.48346385,Ashland,Metropolitan Area Planning Council
+Norwood/Everett Streets and Preserve Way,in_construction,2019,15,0,42.13991542,-71.19630047,Sharon,Metropolitan Area Planning Council
+Millstone Village,in_construction,2019,80,0,42.16342058,-71.43013055,Medway,Metropolitan Area Planning Council
+Merrimack Building Supply Expansion,in_construction,2019,0,29500,42.13710037,-71.47289286,Medway,Metropolitan Area Planning Council
+203 Pond Street,in_construction,2019,12,0,42.21402325,-71.58733878,Hopkinton,Metropolitan Area Planning Council
+Diamond Residences,in_construction,2019,8,0,42.10731295,-71.15872621,Sharon,Metropolitan Area Planning Council
+Springs Road PRD,in_construction,2019,7,,42.52593408,-71.28185034,Bedford,Metropolitan Area Planning Council
+642Main,in_construction,2019,8,999,42.49675433,-71.0691163,Wakefield,Metropolitan Area Planning Council
+Seascape at Weymouth,in_construction,2019,50,0,42.217109,-70.960851,Weymouth Town,Metropolitan Area Planning Council
+399 Congress ,in_construction,2019,414,12895,42.34897436,-71.04669296,Boston,Metropolitan Area Planning Council
+68 South St.,in_construction,2019,16,0,42.27529964,-71.41336881,Framingham,Metropolitan Area Planning Council
+Applegate Farm,in_construction,2019,22,0,42.158686,-71.40536,Medway,Metropolitan Area Planning Council
+268B Cabot Street Addition,in_construction,2019,11,3200,42.55037916,-70.87823587,Beverly,Metropolitan Area Planning Council
+Baseball Academy,in_construction,2019,0,14750,42.55465523,-70.97849156,Peabody,Metropolitan Area Planning Council
+LFB-USA,in_construction,2019,0,65000,42.36759842,-71.57332538,Marlborough,Metropolitan Area Planning Council
+Expeditors,in_construction,2019,0,140000,42.52148685,-70.98012396,Peabody,Metropolitan Area Planning Council
+211 Rantoul Street,in_construction,2019,98,5496,42.5484562,-70.88344242,Beverly,Metropolitan Area Planning Council
+Hunters Ridge,in_construction,2019,19,0,42.20260046,-71.49043032,Hopkinton,Metropolitan Area Planning Council
+12 Enon Expansion,in_construction,2019,4,0,42.58398969,-70.88481784,Beverly,Metropolitan Area Planning Council
+Penny Meadow Lane,in_construction,2019,5,0,42.21072934,-71.48336344,Hopkinton,Metropolitan Area Planning Council
+Tall Pines Estates,in_construction,2019,12,0,42.23274085,-71.54099816,Hopkinton,Metropolitan Area Planning Council
+Odd Fellows Hall: Office Conversion to Residential,in_construction,2019,5,0,42.54784918,-70.87930226,Beverly,Metropolitan Area Planning Council
+Todisco LLC,in_construction,2019,20,7000,42.52558286,-70.92715832,Peabody,Metropolitan Area Planning Council
+Sameron Village- 28 Boston Rd.,in_construction,2019,6,0,42.304746,-71.519199,Southborough,Metropolitan Area Planning Council
+940-958 Boston-Providence Highway,in_construction,2019,0,36750,42.17976831,-71.18890545,Norwood,Metropolitan Area Planning Council
+54 Union Ave.,in_construction,2019,75,3906,42.27995627,-71.41785927,Framingham,Metropolitan Area Planning Council
+Jewett Street Extension,in_construction,2019,1,0,42.56245215,-70.86390123,Beverly,Metropolitan Area Planning Council
+Avalon Norwood,in_construction,2019,198,0,42.19053758,-71.19806196,Norwood,Metropolitan Area Planning Council
+20 Westminster,in_construction,2019,9,0,42.42634985,-71.18291824,Arlington,Metropolitan Area Planning Council
+Trail View Condos,in_construction,2019,18,0,42.44324292,-71.45403162,Maynard,Metropolitan Area Planning Council
+Mill View Condos,in_construction,2019,5,0,42.43089621,-71.45970848,Maynard,Metropolitan Area Planning Council
+Beverly Airport Self Storage,in_construction,2019,0,76950,42.58611776,-70.90787401,Beverly,Metropolitan Area Planning Council
+Vitale - 95 Sam Fonzo Drive,in_construction,2019,0,15000,42.58442457,-70.90658117,Beverly,Metropolitan Area Planning Council
+Exelon,in_construction,2019,0,43947,42.139792,-71.446248,Medway,Metropolitan Area Planning Council
+48 Dunham Ridge,in_construction,2019,0,144000,42.57839116,-70.87287158,Beverly,Metropolitan Area Planning Council
+Wendy's Restaurant & BJ's Gas Station ,in_construction,2019,0,2570,42.16320838,-71.19865116,Norwood,Metropolitan Area Planning Council
+Alta Union House,in_construction,2019,196,2500,42.27791689,-71.41643472,Framingham,Metropolitan Area Planning Council
+480 Franklin,in_construction,2019,210,5000,42.2892498,-71.42902885,Framingham,Metropolitan Area Planning Council
+Cambridge Crossing - 250 North Street,in_construction,2019,0,430000,42.36366866,-71.05245062,Boston,Metropolitan Area Planning Council
+Circle Hill Subdivision,in_construction,2019,3,0,42.51055822,-70.92082951,Salem,Metropolitan Area Planning Council
+28-36 Dell Street,in_construction,2019,23,0,42.5124739,-70.91905428,Salem,Metropolitan Area Planning Council
+201-203 Concord Turnpike,in_construction,2019,320,0,42.3992095,-71.14851961,Cambridge,Metropolitan Area Planning Council
+95 Fawcett Street,in_construction,2019,44,0,42.39229988,-71.14655928,Cambridge,Metropolitan Area Planning Council
+292 Main Street/ MIT Kendall Square Building 4,in_construction,2019,454,426600,42.3620256,-71.0857286,Cambridge,Metropolitan Area Planning Council
+907 Main Street/Hotel,in_construction,2019,0,29860,42.36356369,-71.09949345,Cambridge,Metropolitan Area Planning Council
+249 Third St.,in_construction,2019,84,1540,42.36678032,-71.08209437,Cambridge,Metropolitan Area Planning Council
+305 Webster Ave.,in_construction,2019,35,1546,42.37376954,-71.09424049,Cambridge,Metropolitan Area Planning Council
+Country Cottage,in_construction,2019,0,1,42.14372031,-71.44315496,Medway,Metropolitan Area Planning Council
+"Hillside Village, 80 North Meadows Road",in_construction,2019,16,0,42.19136973,-71.32273502,Medfield,Metropolitan Area Planning Council
+"Chapel Hill Landing aka Country Estates of Medfield, 21, 25, 29 Hospital Road",in_construction,2019,49,0,42.206271,-71.326999,Medfield,Metropolitan Area Planning Council
+"Innovation Point (GE HQ) - Phase 1 ""North Point"" ",in_construction,2019,0,95000,42.34950831,-71.05125173,Boston,Metropolitan Area Planning Council
+Union Point - Brookfield Village,in_construction,2019,108,0,42.15760025,-70.95165888,Weymouth,Metropolitan Area Planning Council
+Union Point -- Woodstone Crossing ,in_construction,2019,200,0,42.15467612,-70.95002694,Weymouth,Metropolitan Area Planning Council
+Avalon Hingham Shipyard II,in_construction,2019,190,0,42.24988952,-70.91563975,Hingham,Metropolitan Area Planning Council
+Union Market,in_construction,2019,282,10600,42.36492357,-71.17719513,Watertown,Metropolitan Area Planning Council
+Lewis Drive Subdivision,in_construction,2019,9,0,42.58999914,-71.01357446,Middleton,Metropolitan Area Planning Council
+2012 Institutional Master Plan Amendment,planning,2019,0,445000,42.33748925,-71.10496443,Boston,Metropolitan Area Planning Council
+Town Fair Tire,planning,2019,0,8335,42.55380382,-71.48037782,Littleton,Metropolitan Area Planning Council
+59 Turnpike Road,planning,2019,0,40000,42.68212431,-70.91815175,Ipswich,Metropolitan Area Planning Council
+174 Middlesex Turnpike,planning,2019,0,240000,42.49173363,-71.22543575,Burlington,Metropolitan Area Planning Council
+Sharon Residences,planning,2019,192,0,42.10274248,-71.22276668,Sharon,Metropolitan Area Planning Council
+Macy School Development,planning,2019,12,,42.10760529,-71.48062719,Bellingham,Metropolitan Area Planning Council
+128 Main Street,planning,2019,17,2079,42.26105198,-71.46510777,Ashland,Metropolitan Area Planning Council
+The Barn at Belmont Day School ,planning,2019,0,25817,42.39573811,-71.18572823,Belmont,Metropolitan Area Planning Council
+National Armenian Studies and Research Library Expansion,planning,2019,0,6300,42.3956309,-71.17377243,Belmont,Metropolitan Area Planning Council
+75 Leonard Street,planning,2019,0,5068,42.39787878,-71.17458801,Belmont,Metropolitan Area Planning Council
+344 Pleasant Street,planning,2019,0,3516,42.40363529,-71.16645937,Belmont,Metropolitan Area Planning Council
+Avalon at Hilltop,planning,2019,280,24000,42.47457723,-71.02491129,Saugus,Metropolitan Area Planning Council
+Crown Home Health,planning,2019,50,15000,42.18923036,-71.05625786,Randolph,Metropolitan Area Planning Council
+255 Turnpike Rd- Comm Can,planning,2019,0,2100,42.29119905,-71.53945541,Southborough,Metropolitan Area Planning Council
+Former convent II,planning,2019,8,0,42.52048527,-70.90560018,Salem,Metropolitan Area Planning Council
+435-439 Lincoln Street,planning,2019,14,0,42.436642,-71.26411912,Lexington,Metropolitan Area Planning Council
+Arsenal Yards,planning,2019,503,380000,42.3620264,-71.15871296,Watertown,Metropolitan Area Planning Council
+99 Andover St,planning,2019,0,9529,42.55526342,-70.96234038,Danvers,Metropolitan Area Planning Council
+South Shore Hospital Expansion- 55 Fogg Rd,planning,2019,0,500000,42.17558416,-70.9542144,Weymouth,Metropolitan Area Planning Council
+18-22 Cherry Hill Dr,planning,2019,0,10000,42.57694334,-70.91780573,Danvers,Metropolitan Area Planning Council
+Bennett Orchard,planning,2019,32,0,42.53304431,-71.51953234,Littleton,Metropolitan Area Planning Council
+Longwood II Residences,planning,2019,115,0,42.33370482,-71.10140228,Boston,Metropolitan Area Planning Council
+Acorda Therapeutics Inc.,planning,2019,0,78000,42.39770798,-71.04118948,Chelsea,Metropolitan Area Planning Council
+Acorn Hill Estates,planning,2019,4,0,42.12964475,-71.39341394,Franklin,Metropolitan Area Planning Council
+9 Burney Street,planning,2019,31,1900,42.331717,-71.099841,Boston,Metropolitan Area Planning Council
+Malden Park Minor League Baseball Stadium- 100 Commercial Street,planning,2019,0,0,42.42406097,-71.07344404,Malden,Metropolitan Area Planning Council
+33 Mt Auburn,planning,2019,24,2115,42.36567114,-71.18283272,Watertown,Metropolitan Area Planning Council
+Parcel Q1 at Boston Marine Industrial Park,planning,2019,0,230000,42.3447,-71.0366,Boston,Metropolitan Area Planning Council
+Emery Flats,planning,2019,200,0,42.522284,-71.136445,Woburn,Metropolitan Area Planning Council
+Holden Oil,planning,2019,0,2500,42.51673032,-70.95260515,Peabody,Metropolitan Area Planning Council
+18 Cedar Street,planning,2019,8,0,42.23049726,-71.52227675,Hopkinton,Metropolitan Area Planning Council
+Route 1 Storage Facility,planning,2019,0,48000,42.535066,-70.990887,Peabody,Metropolitan Area Planning Council
+North Road cafe,planning,2019,1,3150,42.49516369,-71.28582838,Bedford,Metropolitan Area Planning Council
+Without A Hitch,planning,2019,0,24960,42.52476538,-70.92530769,Peabody,Metropolitan Area Planning Council
+Central Street Strip Mall,planning,2019,0,9000,42.53492669,-70.92890303,Peabody,Metropolitan Area Planning Council
+Norwood Light Department,planning,2019,0,65157,42.1875251,-71.17950096,Norwood,Metropolitan Area Planning Council
+40 Sam Fonzo Drive,planning,2019,0,49860,42.57874527,-70.90593924,Beverly,Metropolitan Area Planning Council
+Livingstone 40B Project,projected,2019,200,0,42.20883114,-70.78680896,Scituate,Metropolitan Area Planning Council
+Harrington Driveways,projected,2019,15,0,42.18870872,-70.76364521,Scituate,Metropolitan Area Planning Council
+Nantasket Beachfront Condominiums,cancelled,2020,66,,42.2790187,-70.86659154,Hull,Metropolitan Area Planning Council
+Washington Place,completed,2020,171,39745,42.35175787,-71.20769597,Newton,Metropolitan Area Planning Council
+Hilton Garden Inn,completed,2020,0,153500,42.33211282,-71.11403736,Brookline,Metropolitan Area Planning Council
+8 Banton Street,completed,2020,18,0,42.28827292,-71.06423296,Boston,Metropolitan Area Planning Council
+Epiphany School,completed,2020,0,25220,42.29368866,-71.06356061,Boston,Metropolitan Area Planning Council
+151 Hancock Street,completed,2020,20,0,42.27962308,-71.03371625,Quincy,Metropolitan Area Planning Council
+Endicott Woods Condos,completed,2020,112,0,42.17848331,-71.21400211,Norwood,Metropolitan Area Planning Council
+236 Auburn Street,completed,2020,3,0,42.34564338,-71.24514071,Newton,Metropolitan Area Planning Council
+200 Second Street,completed,2020,0,25500,42.39415308,-71.0444767,Chelsea,Metropolitan Area Planning Council
+Hingham Shipyard,completed,2020,26,0,42.25097442,-70.92283711,Hingham,Metropolitan Area Planning Council
+R & S Residences,completed,2020,36,0,42.23052779,-71.00585531,Braintree,Metropolitan Area Planning Council
+Woburn Armory,completed,2020,18,3000,42.47733327,-71.15148094,Woburn,Metropolitan Area Planning Council
+16 Laurel St,completed,2020,26,0,42.40557866,-71.0635363,Everett,Metropolitan Area Planning Council
+68 Main Street,completed,2020,6,0,42.4033129,-71.06158317,Everett,Metropolitan Area Planning Council
+Quarry Hills II Apartments,completed,2020,269,0,42.23986372,-71.03918941,Quincy,Metropolitan Area Planning Council
+434 Essex St.,completed,2020,42,0,42.48245324,-70.90831313,Swampscott,Metropolitan Area Planning Council
+Malden Center Redevelopment - Exchange Two Hundred ,completed,2020,0,272492,42.42612028,-71.07287859,Malden,Metropolitan Area Planning Council
+114 Brookside Avenue,completed,2020,9,0,42.31066733,-71.10577589,Boston,Metropolitan Area Planning Council
+Ledgeview,completed,2020,238,48000,42.04100648,-71.30594373,Wrentham,Metropolitan Area Planning Council
+Dalrymple School redevelopment,completed,2020,27,0,42.3851593,-70.97316965,Winthrop,Metropolitan Area Planning Council
+The Cook Estate,completed,2020,27,0,42.23565,-70.81882001,Cohasset,Metropolitan Area Planning Council
+839 Beacon Street,completed,2020,45,4500,42.34690934,-71.10295401,Boston,Metropolitan Area Planning Council
+Parcel K,completed,2020,304,232328,42.34743551,-71.03756971,Boston,Metropolitan Area Planning Council
+"""Sanylah Crossing""",completed,2020,36,0,42.16444934,-71.55751865,Milford,Metropolitan Area Planning Council
+"0, 92, 110 Kendall Ave",completed,2020,8,0,42.272378,-71.392937,Natick,Metropolitan Area Planning Council
+Greenbush Park,completed,2020,30,6000,42.17945304,-70.74752576,Scituate,Metropolitan Area Planning Council
+395 West Broadway,completed,2020,24,0,42.33711369,-71.04879579,Boston,Metropolitan Area Planning Council
+Chestnut Place,completed,2020,124,4000,42.24893588,-70.99981504,Quincy,Metropolitan Area Planning Council
+Audi Brookline,completed,2020,0,140580,42.32987519,-71.12493123,Brookline,Metropolitan Area Planning Council
+Treadmark (formerly Ashmont TOD 2),completed,2020,83,5000,42.28369382,-71.06518051,Boston,Metropolitan Area Planning Council
+99 Tremont Street,completed,2020,62,0,42.35125791,-71.17231337,Boston,Metropolitan Area Planning Council
+Two Brookline Place - Boston Children's Hospital ,completed,2020,0,182500,42.33211845,-71.11586725,Brookline,Metropolitan Area Planning Council
+966 Hyde Park Ave,completed,2020,9,0,42.26675872,-71.12068297,Boston,Metropolitan Area Planning Council
+54 Pleasant Street,completed,2020,17,0,42.31490865,-71.05956063,Boston,Metropolitan Area Planning Council
+126-150 Pleasant Street,completed,2020,69,6300,42.4266145,-71.07089339,Malden,Metropolitan Area Planning Council
+520 Dorchester Ave,completed,2020,8,0,42.33147511,-71.05679767,Boston,Metropolitan Area Planning Council
+Harmon Apartments ,completed,2020,36,0,42.28075695,-71.06618707,Boston,Metropolitan Area Planning Council
+Harvard District Energy Facility,completed,2020,0,58275,42.36218193,-71.12029243,Boston,Metropolitan Area Planning Council
+1485 Commonwealth Avenue (Brighton Marine),completed,2020,102,0,42.34777007,-71.14309545,Boston,Metropolitan Area Planning Council
+25 Eleanor Street,completed,2020,20,0,42.39753282,-71.02467671,Chelsea,Metropolitan Area Planning Council
+524-530 Main Street,completed,2020,10,6000,42.45576956,-71.06515969,Melrose,Metropolitan Area Planning Council
+Vita JP,completed,2020,88,25000,42.30529907,-71.1092001,Boston,Metropolitan Area Planning Council
+Village at Taylor Pond - 100 Plank Street,completed,2020,46,4000,42.5162939,-71.23908421,Bedford,Metropolitan Area Planning Council
+483 Summer Street,completed,2020,7,3555,42.42754765,-71.17378527,Arlington,Metropolitan Area Planning Council
+545 EAST THIRD STREET ,completed,2020,18,0,42.336256,-71.038049,Boston,Metropolitan Area Planning Council
+Boston Crossing,completed,2020,12,0,42.518536,-70.908448,Salem,Metropolitan Area Planning Council
+Boston Dog Company,completed,2020,0,1,42.140581,-71.389227,Medway,Metropolitan Area Planning Council
+"960, 968 & 1000 Main Street",completed,2020,8,0,42.4372418,-71.06749398,Malden,Metropolitan Area Planning Council
+One Brookline Place - Boston Children's Hospital Expansion,completed,2020,0,46511,42.33269427,-71.11519288,Brookline,Metropolitan Area Planning Council
+Rocky Woods,completed,2020,7,0,42.1969002,-71.49185407,Holliston,Metropolitan Area Planning Council
+"45 Burnett Street, Jamaica Plain, Boston, MA",completed,2020,44,0,42.30451031,-71.11079051,Boston,Metropolitan Area Planning Council
+Congress Square,completed,2020,35,406950,42.35782554,-71.05687826,Boston,Metropolitan Area Planning Council
+44-46 Medford Street,completed,2020,12,1120,42.37470575,-71.08851835,Somerville,Metropolitan Area Planning Council
+60 Hermon Street,completed,2020,5,0,42.37829392,-70.98601789,Winthrop,Metropolitan Area Planning Council
+1-13 Newport Ave.,completed,2020,80,0,42.27403517,-71.0296421,Quincy,Metropolitan Area Planning Council
+37 Bates Ave,completed,2020,12,0,42.24675254,-71.0341663,Quincy,Metropolitan Area Planning Council
+North Quincy Hotel,completed,2020,0,89000,42.27356997,-71.03002478,Quincy,Metropolitan Area Planning Council
+20 Acorn Park/ 500 Discovery Park,completed,2020,0,132000,42.39843549,-71.14725191,Cambridge,Metropolitan Area Planning Council
+Sterling Hill Stoneham,completed,2020,48,0,42.45043595,-71.08760929,Stoneham,Metropolitan Area Planning Council
+55 Cherry Hill Drive,in_construction,2020,0,98000,42.57826539,-70.91516947,Danvers,Metropolitan Area Planning Council
+2 Falmouth Road,in_construction,2020,1,0,42.42928495,-71.15333006,Arlington,Metropolitan Area Planning Council
+189 Vassar Street/MIT Undergraduate Residence Hall,in_construction,2020,16,156000,42.35858314,-71.09849326,Cambridge,Metropolitan Area Planning Council
+Dexter Southfield School Field House,in_construction,2020,0,47874,42.30642757,-71.13722545,Brookline,Metropolitan Area Planning Council
+Residences at Robbins Brook (Phases II and III),in_construction,2020,54,0,42.51889488,-71.40792931,Acton,Metropolitan Area Planning Council
+Chestnut Hill,in_construction,2020,26,0,42.12710629,-70.70701978,Marshfield,Metropolitan Area Planning Council
+Dana Estates,in_construction,2020,2,0,42.0757081,-71.34385812,Wrentham,Metropolitan Area Planning Council
+Packard Crossing - Phase I & II,in_construction,2020,114,3050,42.35332318,-71.12667254,Boston,Metropolitan Area Planning Council
+"Washington/Dodge, Hilton Hotel",in_construction,2020,56,113,42.51837021,-70.89454888,Salem,Metropolitan Area Planning Council
+Annick Drive,in_construction,2020,3,0,42.19597025,-70.88405784,Hingham,Metropolitan Area Planning Council
+100 Weld St,in_construction,2020,17,0,42.29434713,-71.13578976,Boston,Metropolitan Area Planning Council
+Ken's Food Warehouse- 325 Turnpike,in_construction,2020,0,350000,42.29263297,-71.54797109,Southborough,Metropolitan Area Planning Council
+10-16 Everett Street,in_construction,2020,19,0,42.36866266,-71.03700762,Boston,Metropolitan Area Planning Council
+LCB Senior Living at Penniman Hill,in_construction,2020,90,0,42.184454,-70.90710099,Hingham,Metropolitan Area Planning Council
+Sharon Park South,in_construction,2020,0,74000,42.11966959,-71.2375224,Sharon,Metropolitan Area Planning Council
+20 Boylston Street,in_construction,2020,16,4200,42.33124949,-71.11816891,Brookline,Metropolitan Area Planning Council
+Conservation Lab Charter School,in_construction,2020,0,43500,42.31125834,-71.06932691,Boston,Metropolitan Area Planning Council
+The Ceinture,in_construction,2020,54,0,42.34021864,-71.0563006,Boston,Metropolitan Area Planning Council
+The Edison on the Charles,in_construction,2020,264,,42.37203707,-71.23338943,Waltham,Metropolitan Area Planning Council
+233 Hancock Street,in_construction,2020,36,1250,42.30946864,-71.0602706,Boston,Metropolitan Area Planning Council
+Charles Street Extension Subdivision,in_construction,2020,11,0,42.59465675,-71.08214334,North Reading,Metropolitan Area Planning Council
+Wingate Farm,in_construction,2020,2,0,42.17304216,-71.40977611,Medway,Metropolitan Area Planning Council
+944-946 Saratoga Street,in_construction,2020,9,0,42.38698866,-71.00937062,Boston,Metropolitan Area Planning Council
+500 Talbot Avenue,in_construction,2020,40,3000,42.288609,-71.06586471,Boston,Metropolitan Area Planning Council
+1785 Columbus Ave,in_construction,2020,0,139200,42.32006312,-71.0987056,Boston,Metropolitan Area Planning Council
+100 Hood Park Drive,in_construction,2020,0,75000,42.3813988,-71.07296102,Boston,Metropolitan Area Planning Council
+Bolton Office Park Assisted Living ,in_construction,2020,60,,42.42951456,-71.5989295,Bolton,Metropolitan Area Planning Council
+Center Plaza,in_construction,2020,0,30000,42.35909441,-71.06011661,Boston,Metropolitan Area Planning Council
+Maspenock Woods,in_construction,2020,31,0,42.21266839,-71.55315679,Hopkinton,Metropolitan Area Planning Council
+302 Broadway,in_construction,2020,16,0,42.40320134,-71.059628,Everett,Metropolitan Area Planning Council
+Washington Street Westminster House Project,in_construction,2020,27,0,42.31656035,-71.09667314,Boston,Metropolitan Area Planning Council
+Isabella Lane,in_construction,2020,4,0,42.5237344,-71.28738341,Bedford,Metropolitan Area Planning Council
+Broadstone Bare Cove Alliance ,in_construction,2020,220,0,42.24521279,-70.9254141,Hingham,Metropolitan Area Planning Council
+420-438 West Central Street,in_construction,2020,0,8500,42.08743643,-71.41533114,Franklin,Metropolitan Area Planning Council
+392-398 Cambridge St,in_construction,2020,32,5100,42.35495527,-71.13340329,Boston,Metropolitan Area Planning Council
+Mallard Square Condos,in_construction,2020,7,900,42.38151199,-71.08639493,Somerville,Metropolitan Area Planning Council
+"Former Hood Factory, Icecream Building",in_construction,2020,29,0,42.52465051,-70.90167901,Salem,Metropolitan Area Planning Council
+75 New Street,in_construction,2020,94,0,42.3891307,-71.140231,Cambridge,Metropolitan Area Planning Council
+Public Safety Complex at St. Mark's,in_construction,2020,0,36000,42.300068,-71.52496105,Southborough,Metropolitan Area Planning Council
+Hanover Hill,in_construction,2020,35,,42.5329259,-71.37156523,Carlisle,Metropolitan Area Planning Council
+Hollis Hills Preserve,in_construction,2020,32,,42.20711892,-71.4368856,Holliston,Metropolitan Area Planning Council
+Hopping Brook Bus. Park,in_construction,2020,0,1107750,42.17006324,-71.46551211,Holliston,Metropolitan Area Planning Council
+95 West Street,in_construction,2020,192,5400,42.14535118,-71.25630143,Walpole,Metropolitan Area Planning Council
+Center 128,in_construction,2020,0,740000,42.29787381,-71.21927675,Needham,Metropolitan Area Planning Council
+Harvard University - Science and Engineering Complex,in_construction,2020,0,535000,42.36312018,-71.12590492,Boston,Metropolitan Area Planning Council
+6 Station Street ,in_construction,2020,4,2538,42.24330646,-70.88613082,Hingham,Metropolitan Area Planning Council
+1000 Washington St,in_construction,2020,28,3100,42.22886152,-71.1856249,Dedham,Metropolitan Area Planning Council
+252-254 Adams Street,in_construction,2020,15,0,42.30054052,-71.05889684,Boston,Metropolitan Area Planning Council
+Greystone Crossing,in_construction,2020,23,,42.52014278,-71.36901017,Carlisle,Metropolitan Area Planning Council
+Highlands at Holliston,in_construction,2020,63,0,42.23290163,-71.42451023,Holliston,Metropolitan Area Planning Council
+Andrews School,in_construction,2020,16,0,42.19730753,-71.43071018,Holliston,Metropolitan Area Planning Council
+Old Colony Phase III A,in_construction,2020,115,0,42.33197836,-71.05029345,Boston,Metropolitan Area Planning Council
+Readville Yard 5 Industrial Development,in_construction,2020,0,249845,42.23685306,-71.1433324,Boston,Metropolitan Area Planning Council
+202 Maverick Street - Maverick Shipyard Apartments,in_construction,2020,23,0,42.36905401,-71.03580161,Boston,Metropolitan Area Planning Council
+386-388 Market Street,in_construction,2020,17,612,42.35015037,-71.15256818,Boston,Metropolitan Area Planning Council
+O'Connor Way,in_construction,2020,47,0,42.32779727,-71.05632398,Boston,Metropolitan Area Planning Council
+Copley Place expansion,in_construction,2020,0,114000,42.34729761,-71.07730561,Boston,Metropolitan Area Planning Council
+Gateway Center 401 Bridge Street,in_construction,2020,117,3000,42.51947594,-70.90826845,Salem,Metropolitan Area Planning Council
+The Archer Residences ,in_construction,2020,67,0,42.36022682,-71.06385179,Boston,Metropolitan Area Planning Council
+377 West First street,in_construction,2020,9,0,42.33806327,-71.04493657,Boston,Metropolitan Area Planning Council
+Bulfinch Crossing - 100 Sudbury Street,in_construction,2020,423,1300,42.36217008,-71.05961559,Boston,Metropolitan Area Planning Council
+425 Massachusetts Avenue/Market Central,in_construction,2020,225,17000,42.36375907,-71.10027655,Cambridge,Metropolitan Area Planning Council
+601 Summer Street,in_construction,2020,15,0,42.57855541,-70.71898052,Manchester,Metropolitan Area Planning Council
+Spring Hill Estates,in_construction,2020,5,0,42.23093111,-71.59239904,Hopkinton,Metropolitan Area Planning Council
+83 Morse Street,in_construction,2020,0,66000,42.17254146,-71.20569534,Norwood,Metropolitan Area Planning Council
+1650 Soldiers Field Road,in_construction,2020,0,27000,42.35927723,-71.15245051,Boston,Metropolitan Area Planning Council
+Chestnut Meadow Subdivision- O Chesnut Hill Rd.,in_construction,2020,12,0,42.31502,-71.55921221,Southborough,Metropolitan Area Planning Council
+Regal Lofts,in_construction,2020,40,0,42.1892049,-71.19898567,Norwood,Metropolitan Area Planning Council
+61 Locust Street,in_construction,2020,490,3000,42.40843189,-71.09371073,Medford,Metropolitan Area Planning Council
+287 Old Colony Avenue,in_construction,2020,7,1500,42.33018529,-71.0528787,Boston,Metropolitan Area Planning Council
+Waterside Place - Phase 1B,in_construction,2020,307,3500,42.34752062,-71.04132625,Boston,Metropolitan Area Planning Council
+2451 Washington St,in_construction,2020,16,0,42.32857618,-71.08648126,Boston,Metropolitan Area Planning Council
+Loring Arena Renovations,in_construction,2020,0,0,42.27729786,-71.43088031,Framingham,Metropolitan Area Planning Council
+815 East Fifth Street,in_construction,2020,19,0,42.33365305,-71.0280002,Boston,Metropolitan Area Planning Council
+151 Liverpool Street,in_construction,2020,36,0,42.37344981,-71.03964089,Boston,Metropolitan Area Planning Council
+16 Ronald St,in_construction,2020,54,0,42.30490515,-71.07844739,Boston,Metropolitan Area Planning Council
+enterprise Park,in_construction,2020,128,893000,42.10002934,-70.74849837,Marshfield,Metropolitan Area Planning Council
+187-191 Condor Street,in_construction,2020,9,0,42.38247558,-71.03373249,Boston,Metropolitan Area Planning Council
+Ward Street Condominiums,in_construction,2020,14,0,42.32950401,-71.05431446,Boston,Metropolitan Area Planning Council
+37-43 North Beacon Street,in_construction,2020,81,5000,42.354,-71.1393,Boston,Metropolitan Area Planning Council
+46 Hichborn Street,in_construction,2020,46,0,42.3558056,-71.14312185,Boston,Metropolitan Area Planning Council
+MMHC-Residential Building,in_construction,2020,136,0,42.3358,-71.1094,Boston,Metropolitan Area Planning Council
+Avenu at Natick,in_construction,2020,164,84500,42.30035468,-71.37805,Natick,Metropolitan Area Planning Council
+10 + 20 CityPoint,in_construction,2020,0,450000,42.39610651,-71.2581342,Waltham,Metropolitan Area Planning Council
+1550 Soldiers Field Road & 21 Soldiers Field Place,in_construction,2020,249,0,42.360071,-71.14945,Boston,Metropolitan Area Planning Council
+81 Chestnut Hill Ave,in_construction,2020,15,0,42.34488406,-71.15356316,Boston,Metropolitan Area Planning Council
+Hilton Garden Inn Expansion,in_construction,2020,0,45718,42.38992495,-71.01235391,Boston,Metropolitan Area Planning Council
+399 Binney Street,in_construction,2020,0,172500,42.368181,-71.09027013,Cambridge,Metropolitan Area Planning Council
+Revere Beach Hotel,in_construction,2020,0,100000,42.40530436,-70.99159132,Revere,Metropolitan Area Planning Council
+1470 Tremont Street,in_construction,2020,25,1200,42.33178759,-71.09813827,Boston,Metropolitan Area Planning Council
+135 Morrissey Boulevard,in_construction,2020,0,670000,42.31548479,-71.04955919,Boston,Metropolitan Area Planning Council
+50 Symphony Road - The Henry,in_construction,2020,20,0,42.34292245,-71.08917713,Boston,Metropolitan Area Planning Council
+Newton Centre restaurants,in_construction,2020,0,50000,42.33059201,-71.19373347,Newton,Metropolitan Area Planning Council
+Boston College Harrington Athletics Village Support,in_construction,2020,0,31140,42.34561171,-71.162461,Boston,Metropolitan Area Planning Council
+Seaport District Innovation Square ,in_construction,2020,0,360000,42.345827,-71.03181,Boston,Metropolitan Area Planning Council
+87 Essex Street,in_construction,2020,8,0,42.45696953,-71.0672363,Melrose,Metropolitan Area Planning Council
+Jamaica Park Condominuim,in_construction,2020,29,0,42.30223714,-71.10633073,Boston,Metropolitan Area Planning Council
+Bonkers,in_construction,2020,0,40099,42.546688,-70.98022,Peabody,Metropolitan Area Planning Council
+150 Hancock St,in_construction,2020,13,0,42.27988613,-71.03326132,Quincy,Metropolitan Area Planning Council
+Cambridgeside Galleria Partial Office Conversion,in_construction,2020,0,140000,42.36828328,-71.07710472,Cambridge,Metropolitan Area Planning Council
+Bay Property North,in_construction,2020,0,199150,42.60698264,-71.03122641,Middleton,Metropolitan Area Planning Council
+Ridgewood Estates,in_construction,2020,55,0,42.61047027,-70.99450254,Middleton,Metropolitan Area Planning Council
+212 Hampshire Street/Ryles Redevlopment,in_construction,2020,8,4899,42.37321315,-71.10048547,Cambridge,Metropolitan Area Planning Council
+199 Rantoul Street,in_construction,2020,28,2973,42.5479586,-70.88366605,Beverly,Metropolitan Area Planning Council
+Winning Farm,in_construction,2020,147,0,42.4495552,-71.18687411,Winchester,Metropolitan Area Planning Council
+Hopkinton Tennis Club,in_construction,2020,0,39086,42.2129421,-71.53963889,Hopkinton,Metropolitan Area Planning Council
+11-15 Sunnycrest Avenue OSRD,in_construction,2020,6,0,42.5529486,-70.90632226,Beverly,Metropolitan Area Planning Council
+Alphonsa Lane,in_construction,2020,3,0,42.48139267,-71.28108393,Bedford,Metropolitan Area Planning Council
+Highland Park IV,in_construction,2020,21,0,42.25989289,-71.54826675,Hopkinton,Metropolitan Area Planning Council
+610 Rutherford Ave,in_construction,2020,22,0,42.38352654,-71.07384109,Boston,Metropolitan Area Planning Council
+London Estates,in_construction,2020,18,0,42.07244942,-71.25637817,Foxborough,Metropolitan Area Planning Council
+419-429 Main Street,in_construction,2020,10,3500,42.45358307,-71.06592948,Melrose,Metropolitan Area Planning Council
+160 Main Street LLC,in_construction,2020,12,6000,42.52357552,-70.92093263,Peabody,Metropolitan Area Planning Council
+Ila Bella Estates,in_construction,2020,11,0,42.2892701,-71.51968334,Southborough,Metropolitan Area Planning Council
+The Shoppes at Maynard Crossing,in_construction,2020,323,290000,42.41926905,-71.44949932,Maynard,Metropolitan Area Planning Council
+Parcel U,in_construction,2020,126,1620,42.29747548,-71.11559563,Boston,Metropolitan Area Planning Council
+Harmonic Drive - 42 Dunham Road,in_construction,2020,0,97396,42.57759978,-70.87430558,Beverly,Metropolitan Area Planning Council
+3193 Washington Street,in_construction,2020,40,2560,42.31280899,-71.10158561,Boston,Metropolitan Area Planning Council
+261 Broadway/Squirrelwood,in_construction,2020,23,0,42.36839038,-71.09654969,Cambridge,Metropolitan Area Planning Council
+27 H Street,in_construction,2020,11,0,42.33698648,-71.04180087,Boston,Metropolitan Area Planning Council
+Osborne Hills aka Strongwater Crossing,in_construction,2020,130,0,42.5071607,-70.9281264,Salem,Metropolitan Area Planning Council
+1791 Massachusetts Avenue/Frost Terrace,in_construction,2020,40,0,42.38621175,-71.11865694,Cambridge,Metropolitan Area Planning Council
+Legacy Park ,in_construction,2020,129,860,42.52186186,-70.91131986,Salem,Metropolitan Area Planning Council
+671-675 Concord Avenue,in_construction,2020,98,0,42.39041375,-71.14996607,Cambridge,Metropolitan Area Planning Council
+Woodlands Subdivision,in_construction,2020,26,0,42.49129367,-70.9280742,Salem,Metropolitan Area Planning Council
+25 Hayward Street Garage/MIT Kendall Square,in_construction,2020,0,0,42.36122902,-71.0856036,Cambridge,Metropolitan Area Planning Council
+Duplex,in_construction,2020,2,0,42.505694,-70.893339,Salem,Metropolitan Area Planning Council
+District Court Redevelopment,in_construction,2020,61,3000,42.52271176,-70.8953489,Salem,Metropolitan Area Planning Council
+734 Dudley Street,in_construction,2020,20,3032,42.31806221,-71.06686987,Boston,Metropolitan Area Planning Council
+St Regis Residences,in_construction,2020,114,10700,42.35075984,-71.0428149,Boston,Metropolitan Area Planning Council
+Echelon Seaport,in_construction,2020,447,125000,42.35037799,-71.04378525,Boston,Metropolitan Area Planning Council
+Verizon Wireless new Wireless Communications Facility ,in_construction,2020,0,1,42.13611862,-71.44893687,Medway,Metropolitan Area Planning Council
+New England Heritage Homes,in_construction,2020,16,0,42.29046098,-71.07785842,Boston,Metropolitan Area Planning Council
+Residences at Forest Hills,in_construction,2020,260,4070,42.30079163,-71.11192019,Boston,Metropolitan Area Planning Council
+McKendry Grove Subdivision,in_construction,2020,7,0,42.19363642,-71.12116399,Canton,Metropolitan Area Planning Council
+468-474 Neponset Street,in_construction,2020,4,0,42.16101166,-71.15858767,Canton,Metropolitan Area Planning Council
+Mariella Estates (Hudson Road),in_construction,2020,3,0,42.18388598,-71.14948163,Canton,Metropolitan Area Planning Council
+Yorkshire Estates,in_construction,2020,17,0,42.16796093,-71.08075441,Canton,Metropolitan Area Planning Council
+Cardinal's Corner (Larkin Court),in_construction,2020,9,0,42.1683293,-71.14032721,Canton,Metropolitan Area Planning Council
+1258-1272 Massachusetts Ave,in_construction,2020,40,1463,42.32157466,-71.06215338,Boston,Metropolitan Area Planning Council
+Fenway Center Phase I,in_construction,2020,312,37000,42.34745308,-71.1010332,Boston,Metropolitan Area Planning Council
+101 Heath Street,in_construction,2020,9,1000,42.32654028,-71.10212344,Boston,Metropolitan Area Planning Council
+510-518 Dorchester Avenue,in_construction,2020,8,0,42.33157778,-71.0567805,Boston,Metropolitan Area Planning Council
+Waterside Place Phase 1B,in_construction,2020,307,0,42.34840991,-71.04199095,Boston,Metropolitan Area Planning Council
+Bedford Coast Guard Housing Expansion,in_construction,2020,17,0,42.5004578,-71.2758315,Bedford,Metropolitan Area Planning Council
+"1950 Washington Street Roxbury, Boston, MA",in_construction,2020,31,5300,42.3341226,-71.07957325,Boston,Metropolitan Area Planning Council
+Hendries Ice Cream Factory Redevelopment,in_construction,2020,38,3850,42.2698172,-71.07377678,Milton,Metropolitan Area Planning Council
+181 Morgan Avenue/ CAmbridge Crossing Building Q1,in_construction,2020,0,18851,42.37183472,-71.07621195,Cambridge,Metropolitan Area Planning Council
+Liberty Station at Walpole Center,in_construction,2020,152,7000,42.146171,-71.255087,Walpole,Metropolitan Area Planning Council
+Pennington Crossing,in_construction,2020,186,0,42.14766277,-71.2424215,Walpole,Metropolitan Area Planning Council
+The Skating Club of Boston,in_construction,2020,0,176000,42.19896169,-71.17282424,Norwood,Metropolitan Area Planning Council
+Powder House ,in_construction,2020,48,11300,42.40208056,-71.12526527,Somerville,Metropolitan Area Planning Council
+60 Cross Street East,in_construction,2020,75,0,42.39067692,-71.08448235,Somerville,Metropolitan Area Planning Council
+519 Broadway,in_construction,2020,55,1000,42.39776454,-71.10511254,Somerville,Metropolitan Area Planning Council
+1 Earle Street: (Boynton Yards Phase 1: Bldg 1),in_construction,2020,0,153000,42.37463974,-71.09059576,Somerville,Metropolitan Area Planning Council
+Key Hotel (373 Beacon Street),in_construction,2020,0,21000,42.38632675,-71.1159949,Somerville,Metropolitan Area Planning Council
+320-329 Revere Beach Boulevard (BLVD),in_construction,2020,145,2500,42.41939606,-70.98627264,Revere,Metropolitan Area Planning Council
+LaQuinta Hotel,in_construction,2020,0,32500,42.42345201,-71.00839797,Revere,Metropolitan Area Planning Council
+Avid Hotel,in_construction,2020,0,33800,42.42019586,-71.00191655,Revere,Metropolitan Area Planning Council
+1141 Revere Beach Pkwy,in_construction,2020,0,3000,42.4074114,-71.02542666,Revere,Metropolitan Area Planning Council
+439 Revere Beach Blvd,in_construction,2020,34,0,42.42520558,-70.98278049,Revere,Metropolitan Area Planning Council
+Haynes House Modernization,in_construction,2020,0,0,42.33271223,-71.08386484,Boston,Metropolitan Area Planning Council
+Dudley Square Branch Library,in_construction,2020,0,0,42.32809256,-71.08366863,Boston,Metropolitan Area Planning Council
+Garrison Trotter Phase II,in_construction,2020,18,0,42.31511919,-71.09042914,Boston,Metropolitan Area Planning Council
+18-26 Chauncey Street Basement Units,in_construction,2020,9,0,42.37932824,-71.12281371,Cambridge,Metropolitan Area Planning Council
+4945 Washington Street,in_construction,2020,46,0,42.26861254,-71.1497973,Boston,Metropolitan Area Planning Council
+484 Quincy Avenue,in_construction,2020,14,0,42.23725203,-70.98075318,Quincy,Metropolitan Area Planning Council
+The Shoppes at Simonds Park,in_construction,2020,29,48000,42.50793201,-71.19602048,Burlington,Metropolitan Area Planning Council
+321 Harrison Avenue Redvelopment,in_construction,2020,0,235000,42.34625711,-71.06397852,Boston,Metropolitan Area Planning Council
+Rhode Island Road Extension,in_construction,2020,3,0,42.57006037,-71.20526568,Wilmington,Metropolitan Area Planning Council
+370-380 Harrison Ave,in_construction,2020,273,8500,42.34416658,-71.06367182,Boston,Metropolitan Area Planning Council
+The Cosmopolitan,in_construction,2020,63,0,42.33716448,-71.07320456,Boston,Metropolitan Area Planning Council
+The Smith South End - Harrison Albany Block,in_construction,2020,650,100000,42.33871769,-71.06977511,Boston,Metropolitan Area Planning Council
+Ledges at Woburn,in_construction,2020,168,0,42.51863498,-71.16096304,Woburn,Metropolitan Area Planning Council
+Medway Green,in_construction,2020,8,0,42.14599282,-71.42941528,Medway,Metropolitan Area Planning Council
+175 McClellan Highway,planning,2020,300,,42.38594737,-71.0171614,Boston,Metropolitan Area Planning Council
+227 Grove St,planning,2020,36,0,42.48717092,-71.24113625,Lexington,Metropolitan Area Planning Council
+74 Cox Street,planning,2020,16,0,42.40016204,-71.56540181,Hudson,Metropolitan Area Planning Council
+Boston Cargo Terminal,planning,2020,0,510552,42.34681463,-71.02856955,Boston,Metropolitan Area Planning Council
+Parcel 1 (MTA) Simpson Housing Bulfinch,planning,2020,260,17000,42.36563259,-71.05876705,Boston,Metropolitan Area Planning Council
+Prudential Redevelopment,planning,2020,188,422000,42.34730547,-71.08145807,Boston,Metropolitan Area Planning Council
+Thurston Acres,planning,2020,6,,42.06185441,-71.30779128,Wrentham,Metropolitan Area Planning Council
+599-603 Summer Street,planning,2020,21,0,42.45810875,-70.97253853,Lynn,Metropolitan Area Planning Council
+Coolidge Street Office/Retail,planning,2020,0,4230,42.39734079,-71.60282274,Hudson,Metropolitan Area Planning Council
+EMC Corp Southborough,planning,2020,0,1200000,42.28359975,-71.55136172,Southborough,Metropolitan Area Planning Council
+The Coolidge Phase II,planning,2020,56,0,42.35427582,-71.40396906,Sudbury,Metropolitan Area Planning Council
+Minuteman High School,planning,2020,0,257745,42.44586013,-71.269316,Lexington,Metropolitan Area Planning Council
+Finnerty's Village,planning,2020,0,22720,42.32175064,-71.36476428,Wayland,Metropolitan Area Planning Council
+Maple Preserve,planning,2020,10,0,42.10664586,-71.41185998,Franklin,Metropolitan Area Planning Council
+Stavis Seafood,planning,2020,0,201000,42.34694591,-71.03272354,Boston,Metropolitan Area Planning Council
+25 Fid Kennedy,planning,2020,0,157000,42.3463189,-71.02647761,Boston,Metropolitan Area Planning Council
+Ye Olde Brick Building Redevelopment,planning,2020,84,1500,42.22100111,-70.98227581,Braintree,Metropolitan Area Planning Council
+104 Boston Post Road,planning,2020,154,0,42.36820821,-71.27246974,Weston,Metropolitan Area Planning Council
+82 Broad Street,planning,2020,8,0,42.21653801,-70.96357004,Weymouth,Metropolitan Area Planning Council
+Rosegate of Wrentham,planning,2020,220,0,42.04225217,-71.30752642,Wrentham,Metropolitan Area Planning Council
+Kendall Village,planning,2020,16,0,42.38992416,-71.28939093,Weston,Metropolitan Area Planning Council
+Hillside Estates,planning,2020,15,0,42.2524787,-71.48650553,Ashland,Metropolitan Area Planning Council
+73 Olive Street Subdivision,planning,2020,4,0,42.2410435,-71.47748703,Ashland,Metropolitan Area Planning Council
+Village at Silver Hill,planning,2020,10,0,42.39383349,-71.30229689,Weston,Metropolitan Area Planning Council
+900 Worcester St,planning,2020,0,378000,42.30439282,-71.31813691,Wellesley,Metropolitan Area Planning Council
+1060 Grove St,planning,2020,39,0,42.329208,-71.46309833,Framingham,Metropolitan Area Planning Council
+231 Worcester Rd,planning,2020,0,4140,42.29882069,-71.40390506,Framingham,Metropolitan Area Planning Council
+133 Cottage St,planning,2020,30,0,42.26560544,-71.34407343,Natick,Metropolitan Area Planning Council
+Lifetime Green Homes,planning,2020,20,0,42.51213037,-71.33292786,Carlisle,Metropolitan Area Planning Council
+Wellington Drive Subdivision,planning,2020,5,0,42.53965665,-71.467097,Littleton,Metropolitan Area Planning Council
+271 Great Road,planning,2020,1,4890,42.43551756,-71.49672953,Stow,Metropolitan Area Planning Council
+20 Foster Street,planning,2020,0,20700,42.53789287,-71.48352486,Littleton,Metropolitan Area Planning Council
+Alumni Field,planning,2020,0,1100,42.54276069,-71.48534793,Littleton,Metropolitan Area Planning Council
+80 Ayer Road,planning,2020,0,9100,42.54506098,-71.51898231,Littleton,Metropolitan Area Planning Council
+28-44 Essex Road,planning,2020,174,0,42.66471838,-70.83363705,Ipswich,Metropolitan Area Planning Council
+Pulte Homes,planning,2020,450,0,42.58340735,-71.12623819,North Reading,Metropolitan Area Planning Council
+Primrose Farm,planning,2020,40,0,42.69149858,-70.84599998,Ipswich,Metropolitan Area Planning Council
+9 Chelsea Street,planning,2020,0,26000,42.37012866,-71.03802062,Boston,Metropolitan Area Planning Council
+Residences at Park Central,planning,2020,180,0,42.2901922,-71.56039336,Southborough,Metropolitan Area Planning Council
+21 Crown,planning,2020,8,0,42.35081088,-71.1207265,Brookline,Metropolitan Area Planning Council
+One Post Office Square Expansion,planning,2020,0,140000,42.3568065,-71.05498186,Boston,Metropolitan Area Planning Council
+140-150 Line Street,planning,2020,14,,42.37437417,-71.10289475,Somerville,Metropolitan Area Planning Council
+Hult Business School IMP + Addition,planning,2020,0,44000,42.34745814,-71.1640351,Boston,Metropolitan Area Planning Council
+Rolling Green,planning,2020,30,0,42.66445612,-70.93117193,Topsfield,Metropolitan Area Planning Council
+Norway Farms Subdivision,planning,2020,13,0,42.1202244,-71.34288216,Norfolk,Metropolitan Area Planning Council
+Eversource Energy,planning,2020,0,3840,42.13922889,-71.44898784,Medway,Metropolitan Area Planning Council
+Paul Revere Estates,planning,2020,5,0,42.15380299,-71.39811628,Medway,Metropolitan Area Planning Council
+231 Pond Street - Garage,planning,2020,0,0,42.24486344,-71.43118838,Ashland,Metropolitan Area Planning Council
+630 East Second Street,planning,2020,13,0,42.33752462,-71.03788685,Boston,Metropolitan Area Planning Council
+Irving Oil -South Bellingham,planning,2020,0,7725,42.02397843,-71.49167289,Bellingham,Metropolitan Area Planning Council
+Bonvie Homes - Bellingham,planning,2020,30,,42.02077652,-71.48289285,Bellingham,Metropolitan Area Planning Council
+470 Main Street,planning,2020,0,2570,42.42996445,-71.5884386,Bolton,Metropolitan Area Planning Council
+Houghton Farm Subdivision,planning,2020,15,,42.44536013,-71.59027712,Bolton,Metropolitan Area Planning Council
+925 Turnpike Street ,planning,2020,0,23014,42.1539615,-71.1067046,Canton,Metropolitan Area Planning Council
+Housing Authority Parcel,planning,2020,45,0,42.24171361,-70.91171805,Hingham,Metropolitan Area Planning Council
+125 Nashua St,planning,2020,0,90372,42.36784638,-71.06492659,Boston,Metropolitan Area Planning Council
+"Bartolini Builders, Inc",planning,2020,0,48000,42.28974078,-71.54593116,Southborough,Metropolitan Area Planning Council
+24 School Street,planning,2020,12,0,42.32270173,-71.35603259,Wayland,Metropolitan Area Planning Council
+Dunkin Donuts,planning,2020,0,1000,42.19410232,-71.02867111,Braintree,Metropolitan Area Planning Council
+154-160 Green Street Mixed-Use Project,planning,2020,13,4000,42.31048003,-71.10658042,Boston,Metropolitan Area Planning Council
+North Shore Boat Works,planning,2020,39,,42.43585042,-70.97302252,Revere,Metropolitan Area Planning Council
+4-6 Newbury Street,planning,2020,0,49000,42.35229535,-71.07156541,Boston,Metropolitan Area Planning Council
+101 Dawes Street,planning,2020,0,482136,42.37216306,-71.07749334,Cambridge,Metropolitan Area Planning Council
+Radio Station,planning,2020,7,,42.50793728,-70.84493127,Marblehead,Metropolitan Area Planning Council
+Mugar Site,planning,2020,10,,42.400836,-71.14881571,Arlington,Metropolitan Area Planning Council
+"Ridgewood at Stow, Boxboro Road",planning,2020,66,0,42.44975364,-71.51087949,Stow,Metropolitan Area Planning Council
+Union Square Revitalization: 7.1 & 7.2,planning,2020,50,0,42.38014296,-71.09626338,Somerville,Metropolitan Area Planning Council
+Gerald Road Ext,planning,2020,5,0,42.47451189,-71.08350125,Stoneham,Metropolitan Area Planning Council
+Lovers Lane,planning,2020,2,0,42.04084649,-71.34492963,Wrentham,Metropolitan Area Planning Council
+Waltham Overlook,planning,2020,207,0,42.40679424,-71.23139748,Waltham,Metropolitan Area Planning Council
+Sophia Rd ANR,planning,2020,1,0,42.49983903,-70.93225185,Salem,Metropolitan Area Planning Council
+1299 Beacon St,planning,2020,74,12285,42.34187973,-71.12002337,Brookline,Metropolitan Area Planning Council
+958 Commercial St,planning,2020,3,0,42.22430843,-70.93426599,Weymouth,Metropolitan Area Planning Council
+Eagle Brook Commons,planning,2020,100,0,42.07378745,-71.34997572,Wrentham,Metropolitan Area Planning Council
+97 North Main Street,planning,2020,19,0,42.60175312,-71.02539625,Middleton,Metropolitan Area Planning Council
+"181-185 West First Street and 184, 190 and 206 West Second Street",planning,2020,97,4000,42.34250384,-71.05063975,Boston,Metropolitan Area Planning Council
+Herring Brook Meadow,planning,2020,60,,42.16921213,-70.74369889,Scituate,Metropolitan Area Planning Council
+Overlook Commons,planning,2020,28,,42.26318916,-71.45312351,Ashland,Metropolitan Area Planning Council
+46 West Union St.,planning,2020,0,5220,42.2526737,-71.4693259,Ashland,Metropolitan Area Planning Council
+Tripolis,planning,2020,8,,42.34338623,-71.36403385,Wayland,Metropolitan Area Planning Council
+Cranberry Hill Associates,planning,2020,0,79000,42.48502562,-71.27816538,Bedford,Metropolitan Area Planning Council
+Beaulieu Business Park North,planning,2020,0,56190,42.07285826,-71.42356724,Franklin,Metropolitan Area Planning Council
+Union Square Revitalization: D-4.1,planning,2020,0,33000,42.37787474,-71.09535682,Somerville,Metropolitan Area Planning Council
+30 Cushing Drive,planning,2020,0,45000,42.0833668,-71.29985678,Wrentham,Metropolitan Area Planning Council
+Choice Hotels,planning,2020,0,,42.3995587,-71.04119649,Chelsea,Metropolitan Area Planning Council
+Hartford Village II,planning,2020,18,0,42.11473955,-71.47765373,Bellingham,Metropolitan Area Planning Council
+Barrel Lane,planning,2020,15,,42.14925802,-70.79575641,Norwell,Metropolitan Area Planning Council
+North Shore Medical Center,planning,2020,0,118000,42.51077618,-70.90711534,Salem,Metropolitan Area Planning Council
+Cypress Apartments at Brookline Hills,planning,2020,99,0,42.33088677,-71.12635062,Brookline,Metropolitan Area Planning Council
+Bass Point Overlay District,planning,2020,28,0,42.42105814,-70.93191211,Nahant,Metropolitan Area Planning Council
+Keuka Rd Subdivision,planning,2020,11,0,42.45624754,-71.37673123,Concord,Metropolitan Area Planning Council
+Barberry Homes,planning,2020,174,0,42.14774121,-71.21373556,Walpole,Metropolitan Area Planning Council
+Puddingstone at Chestnut Hill,planning,2020,226,0,42.30279247,-71.16100659,Brookline,Metropolitan Area Planning Council
+333 Perkins Row,planning,2020,70,0,42.65301131,-70.91786346,Topsfield,Metropolitan Area Planning Council
+Boston College IMP - 10 Year Plan,planning,2020,1,268000,42.34372617,-71.16069403,Boston,Metropolitan Area Planning Council
+Norfolk Police Headquarters,planning,2020,0,28291,42.09055419,-71.3056119,Norfolk,Metropolitan Area Planning Council
+400 Wheeler Rd,planning,2020,0,115000,42.47489596,-71.21624998,Burlington,Metropolitan Area Planning Council
+Weaver,planning,2020,1,0,42.60561986,-70.89002481,Wenham,Metropolitan Area Planning Council
+The Villas at Vaughan Place,planning,2020,15,0,42.48112888,-70.92674081,Swampscott,Metropolitan Area Planning Council
+Deer Common,planning,2020,14,,42.19496153,-70.7644953,Scituate,Metropolitan Area Planning Council
+William Street Ext. (High Rock),planning,2020,57,,42.44079942,-71.04343473,Malden,Metropolitan Area Planning Council
+Stockbridge Woods,planning,2020,74,0,42.18740735,-70.73543405,Scituate,Metropolitan Area Planning Council
+Devonshire@495 Center (435 Forest St),planning,2020,0,600000,42.32589166,-71.59161251,Marlborough,Metropolitan Area Planning Council
+2 Florence Street,planning,2020,0,7700,42.42764802,-71.07362,Malden,Metropolitan Area Planning Council
+39 Howard Street,planning,2020,0,7452,42.27759012,-71.41799264,Framingham,Metropolitan Area Planning Council
+Village Square,planning,2020,0,70000,42.25208866,-71.43174237,Ashland,Metropolitan Area Planning Council
+Carberry Property Condominiums,planning,2020,70,0,42.22445014,-71.11387827,Milton,Metropolitan Area Planning Council
+River's Edge,planning,2020,188,0,42.36338584,-71.38092129,Wayland,Metropolitan Area Planning Council
+White Street Subdivision,planning,2020,6,0,42.16590245,-70.94925155,Weymouth,Metropolitan Area Planning Council
+Babcock Place,planning,2020,62,0,42.34788209,-71.1216263,Brookline,Metropolitan Area Planning Council
+Twenty Wayland,planning,2020,100,204950,42.36514022,-71.37008608,Wayland,Metropolitan Area Planning Council
+Simon Hill Village,planning,2020,80,,42.16568989,-70.83307031,Norwell,Metropolitan Area Planning Council
+Cabot Ridge Apartments,planning,2020,176,0,42.37741229,-71.55773075,Hudson,Metropolitan Area Planning Council
+"Riverview Place, Salem Suede, Mason & Flint",planning,2020,130,5540,42.52247083,-70.90593862,Salem,Metropolitan Area Planning Council
+Carlson Way,planning,2020,23,0,42.48917615,-71.16700035,Woburn,Metropolitan Area Planning Council
+125 Sumner St,planning,2020,50,0,42.36943297,-71.04199989,Boston,Metropolitan Area Planning Council
+40 Green Street,planning,2020,0,550000,42.37603571,-71.26809667,Waltham,Metropolitan Area Planning Council
+Coventry Estates,planning,2020,9,0,42.49286403,-71.09579226,Stoneham,Metropolitan Area Planning Council
+"Fenn School, 516 Monument St.",planning,2020,0,16030,42.47454248,-71.34942208,Concord,Metropolitan Area Planning Council
+Mission Hill Flats,planning,2020,40,7200,42.33200241,-71.09741933,Boston,Metropolitan Area Planning Council
+59  North Main St,planning,2020,12,0,42.25176443,-71.36985819,Sherborn,Metropolitan Area Planning Council
+317 Belgrade Ave,planning,2020,21,5980,42.28623843,-71.14485622,Boston,Metropolitan Area Planning Council
+Widowmaker Brewery,planning,2020,0,7000,42.22072913,-71.03677952,Braintree,Metropolitan Area Planning Council
+Residences of South Brookline,planning,2020,161,0,42.2990729,-71.15521219,Brookline,Metropolitan Area Planning Council
+Sharon Gallery,planning,2020,225,450000,42.10339598,-71.22604038,Sharon,Metropolitan Area Planning Council
+Former Ventron site,planning,2020,62,0,42.54059608,-70.88817951,Beverly,Metropolitan Area Planning Council
+Jasper Hill Vistas,planning,2020,31,,42.20255946,-71.42999749,Holliston,Metropolitan Area Planning Council
+The Collings Foundation,planning,2020,0,66000,42.40620224,-71.50710044,Stow,Metropolitan Area Planning Council
+The Glen,planning,2020,10,,42.20324382,-70.81271927,Scituate,Metropolitan Area Planning Council
+Marshhawk Way,planning,2020,13,0,42.11692973,-70.70806064,Marshfield,Metropolitan Area Planning Council
+Doherty Lane Extension,planning,2020,5,0,42.47220934,-71.09536199,Stoneham,Metropolitan Area Planning Council
+Fallon Road - Chesterton Property,planning,2020,200,0,42.46995271,-71.11032,Stoneham,Metropolitan Area Planning Council
+Union Square Revitalization: D-1.1,planning,2020,0,58000,42.37969799,-71.0926684,Somerville,Metropolitan Area Planning Council
+Highland Green,planning,2020,22,0,42.10239385,-70.74019956,Marshfield,Metropolitan Area Planning Council
+Coolidge Crossing,planning,2020,88,0,42.26737783,-71.38075075,Sherborn,Metropolitan Area Planning Council
+Black Birch Phase II,planning,2020,16,0,42.43847067,-71.42449021,Concord,Metropolitan Area Planning Council
+Pleasant Street Condominiums,planning,2020,12,0,42.16433338,-71.20848613,Norwood,Metropolitan Area Planning Council
+"Ford's Hill Estate, Nixon Road",planning,2020,8,0,42.34439127,-71.47934637,Framingham,Metropolitan Area Planning Council
+289 Walk Hill St,planning,2020,106,0,42.28778898,-71.10733786,Boston,Metropolitan Area Planning Council
+Group Home,planning,2020,0,,42.3601546,-71.36096345,Wayland,Metropolitan Area Planning Council
+MathWorks Lakeside Campus Parking and Access Improvements,planning,2020,0,460000,42.30173289,-71.37472956,Natick,Metropolitan Area Planning Council
+Ice House mixed-use development,planning,2020,0,16400,42.25039596,-71.09446647,Milton,Metropolitan Area Planning Council
+Old Essex Estates,planning,2020,6,0,42.61221664,-71.02723556,Middleton,Metropolitan Area Planning Council
+Milford Crossing Redevelopment,planning,2020,0,137000,42.14963524,-71.48802886,Milford,Metropolitan Area Planning Council
+Center at Corporate Drive,planning,2020,270,0,42.49378849,-71.19120889,Burlington,Metropolitan Area Planning Council
+Winter Woods,planning,2020,48,,42.2235341,-71.43173833,Holliston,Metropolitan Area Planning Council
+250 West Union Street,planning,2020,60,10000,42.24250047,-71.48069359,Ashland,Metropolitan Area Planning Council
+White Barn Lane,planning,2020,40,,42.15539561,-70.81220424,Norwell,Metropolitan Area Planning Council
+Cedar Ridge Estates,planning,2020,204,,42.20277206,-71.4791083,Holliston,Metropolitan Area Planning Council
+Smitty's Way,planning,2020,6,0,42.49584076,-71.11652459,Stoneham,Metropolitan Area Planning Council
+Maple Woods,planning,2020,60,0,42.59864882,-70.92566312,Wenham,Metropolitan Area Planning Council
+Greenway Apartments,planning,2020,29,8100,42.36983562,-71.03711847,Boston,Metropolitan Area Planning Council
+13B Commonwealth Avenue,planning,2020,0,6000,42.45795896,-71.39625897,Concord,Metropolitan Area Planning Council
+Lowes @ former Raytheon Parcels,planning,2020,0,100000,42.3706459,-71.21719454,Waltham,Metropolitan Area Planning Council
+268-292 Edge Hill Road,planning,2020,120,0,42.15155852,-71.17249181,Sharon,Metropolitan Area Planning Council
+19 R Park Ave,planning,2020,34,0,42.42556454,-71.18242728,Arlington,Metropolitan Area Planning Council
+Westwood Estates,planning,2020,10,0,42.20657673,-71.16810809,Westwood,Metropolitan Area Planning Council
+0 Pond Street  (Franklin),planning,2020,96,0,42.09441464,-71.42896454,Franklin,Metropolitan Area Planning Council
+Ridgecrest Village Apartments Expansion,planning,2020,92,,42.25795325,-71.15037096,Boston,Metropolitan Area Planning Council
+35-37 Main Street,planning,2020,0,,42.5687565,-71.1085028,North Reading,Metropolitan Area Planning Council
+Meadow Walk Master Development Plan,planning,2020,310,35000,42.36282313,-71.42988903,Sudbury,Metropolitan Area Planning Council
+Hopkinton Village Center,planning,2020,9,28000,42.22789815,-71.52082545,Hopkinton,Metropolitan Area Planning Council
+130 Eastern Ave,planning,2020,4,0,42.62403716,-70.64018134,Gloucester,Metropolitan Area Planning Council
+Campanelli Business Park,planning,2020,0,900000,42.09130944,-71.42600498,Franklin,Metropolitan Area Planning Council
+Almeda Form C,planning,2020,2,0,42.51184457,-70.91197024,Salem,Metropolitan Area Planning Council
+36 Muller Rd Planned Development District,planning,2020,83,150000,42.47383211,-71.20427222,Burlington,Metropolitan Area Planning Council
+Wenham Pines,planning,2020,23,,42.5962169,-70.886806,Wenham,Metropolitan Area Planning Council
+Forest Ridge Residences,planning,2020,296,0,42.47090724,-71.11466926,Winchester,Metropolitan Area Planning Council
+Joanne Drive,planning,2020,7,0,42.43329214,-71.51444077,Stow,Metropolitan Area Planning Council
+Robey Street Condominiums,planning,2020,9,0,42.3215831,-71.0687072,Boston,Metropolitan Area Planning Council
+457-469A West Broadway,planning,2020,44,13500,42.3357783,-71.0465486,Boston,Metropolitan Area Planning Council
+BMIP Expansion (Includes Massport Marine Terminal),planning,2020,0,456000,42.34625513,-71.02556281,Boston,Metropolitan Area Planning Council
+Stonebridge Road,planning,2020,4,,42.35854191,-71.35937192,Wayland,Metropolitan Area Planning Council
+455 Harvard Street,planning,2020,17,1735,42.3466942,-71.12801068,Brookline,Metropolitan Area Planning Council
+54 Middlesex Turnpike,planning,2020,0,2400,42.51209691,-71.23912657,Bedford,Metropolitan Area Planning Council
+Couper Farm Estates,planning,2020,50,0,42.53913916,-71.45850093,Littleton,Metropolitan Area Planning Council
+Parcel M,planning,2020,0,79000,42.40134953,-70.98934446,Revere,Metropolitan Area Planning Council
+Lynnfield Village,planning,2020,64,0,42.50065737,-71.0187173,Saugus,Metropolitan Area Planning Council
+Hickory Hills Residential Subdivision,planning,2020,37,0,42.15078986,-71.36945236,Millis,Metropolitan Area Planning Council
+40B and 40R projects,planning,2020,40,,42.49892941,-70.86404793,Marblehead,Metropolitan Area Planning Council
+Jewish Community Housing for the Elderly,planning,2020,62,5000,42.34441144,-71.12608545,Brookline,Metropolitan Area Planning Council
+270 Baker St,planning,2020,60,0,42.2788663,-71.16818756,Boston,Metropolitan Area Planning Council
+Harbor Village,planning,2020,30,4000,42.61340719,-70.66068267,Gloucester,Metropolitan Area Planning Council
+Ten Florence Expansion,planning,2020,22,0,42.42826987,-71.07334062,Malden,Metropolitan Area Planning Council
+Scituate Hill Commercial Subdivision,planning,2020,0,65,42.23826891,-70.82970758,Cohasset,Metropolitan Area Planning Council
+Proprietor's Marketplace,planning,2020,10,16160,42.10362492,-70.74018661,Marshfield,Metropolitan Area Planning Council
+18 Union St,planning,2020,5,5800,42.11805365,-71.32558956,Norfolk,Metropolitan Area Planning Council
+Stonewall Audubon Circle,planning,2020,53,,42.34621476,-71.10315419,Boston,Metropolitan Area Planning Council
+Woodland Acres,planning,2020,16,,42.6735033,-70.63551486,Rockport,Metropolitan Area Planning Council
+286-290 Tremont Street,planning,2020,171,0,42.345082,-71.070436,Boston,Metropolitan Area Planning Council
+Parker and Terrace Street,planning,2020,44,4124,42.32940363,-71.09793006,Boston,Metropolitan Area Planning Council
+28 S Bolton,planning,2020,36,0,42.34622944,-71.54561296,Marlborough,Metropolitan Area Planning Council
+Tavern on the Green,planning,2020,55,10344,42.34763711,-71.54487851,Marlborough,Metropolitan Area Planning Council
+Beech Brook Farms Subdivision,planning,2020,5,0,42.61824751,-71.03574361,Middleton,Metropolitan Area Planning Council
+Summer Court,planning,2020,630,44370,42.40030817,-71.01230597,Chelsea,Metropolitan Area Planning Council
+Marlborough on Main,planning,2020,47,4032,42.34691772,-71.54894377,Marlborough,Metropolitan Area Planning Council
+170 Cottage Street,planning,2020,66,0,42.39017726,-71.02537118,Chelsea,Metropolitan Area Planning Council
+Cross Roads Redevelopment,planning,2020,375,0,42.2175243,-71.54481548,Hopkinton,Metropolitan Area Planning Council
+1005 Broadway,planning,2020,42,1131,42.40249004,-71.0182279,Chelsea,Metropolitan Area Planning Council
+171 Tremont Street,planning,2020,23,1200,42.46505597,-71.06831398,Melrose,Metropolitan Area Planning Council
+Avalon Marlborough (Expansion),planning,2020,123,0,42.32896747,-71.58217287,Marlborough,Metropolitan Area Planning Council
+487 Lincoln Street,planning,2020,9,0,42.34517597,-71.56127242,Marlborough,Metropolitan Area Planning Council
+27 Jefferson Street,planning,2020,11,0,42.35023306,-71.55431659,Marlborough,Metropolitan Area Planning Council
+245 Cabot Street Expansion,planning,2020,24,0,42.5494169,-70.87771809,Beverly,Metropolitan Area Planning Council
+Northshore Mall Expansion,planning,2020,0,130000,42.54173966,-70.94339091,Peabody,Metropolitan Area Planning Council
+Hayden Rowe Lofts,planning,2020,17,8000,42.22573474,-71.51799072,Hopkinton,Metropolitan Area Planning Council
+Dearborn Apartments,planning,2020,180,0,42.52445651,-70.99184713,Peabody,Metropolitan Area Planning Council
+175 Millwood St.,planning,2020,129,0,42.32064046,-71.45894925,Framingham,Metropolitan Area Planning Council
+80 Kendall St.,planning,2020,60,0,42.27849161,-71.41493557,Framingham,Metropolitan Area Planning Council
+Christopher Heights of Concord at Junction Village,planning,2020,83,0,42.46076919,-71.39484731,Concord,Metropolitan Area Planning Council
+117 Broadway,planning,2020,14,5000,42.41036333,-71.14047374,Arlington,Metropolitan Area Planning Council
+31 Main Street,planning,2020,5,1500,42.43272386,-71.45172784,Maynard,Metropolitan Area Planning Council
+Livingstone Avenue Extension Subdivision,planning,2020,3,0,42.54791851,-70.8963697,Beverly,Metropolitan Area Planning Council
+42 Summer Street,planning,2020,20,0,42.43360969,-71.45404204,Maynard,Metropolitan Area Planning Council
+40R Smart Growth Overlay District,planning,2020,75,0,42.56821411,-70.87976617,Beverly,Metropolitan Area Planning Council
+19 Flutie Pass,planning,2020,175,32000,42.30042949,-71.39130351,Framingham,Metropolitan Area Planning Council
+Bedford Business Park Phase 3,planning,2020,0,70000,42.5056529,-71.24395777,Bedford,Metropolitan Area Planning Council
+Cape Club Residential Development,planning,2020,60,0,42.15258676,-71.18246325,Sharon,Metropolitan Area Planning Council
+Lighthouse I,planning,2020,21,0,42.518436,-70.89159,Salem,Metropolitan Area Planning Council
+City Hall Annex,planning,2020,14,0,42.520932,-70.895879,Salem,Metropolitan Area Planning Council
+Lighthouse II,planning,2020,25,0,42.515108,-70.889758,Salem,Metropolitan Area Planning Council
+84 Congress ,planning,2020,12,0,42.516481,-70.889726,Salem,Metropolitan Area Planning Council
+University Square,planning,2020,50,0,42.509559,-70.896572,Salem,Metropolitan Area Planning Council
+Ferris Junkyard,planning,2020,42,0,42.526383,-70.897892,Salem,Metropolitan Area Planning Council
+Traders Village,planning,2020,212,0,42.5009546,-70.91967117,Salem,Metropolitan Area Planning Council
+Magic Muffler,planning,2020,6,0,42.530827,-70.888937,Salem,Metropolitan Area Planning Council
+Ravenna ANR,planning,2020,2,0,42.502323,-70.9298,Salem,Metropolitan Area Planning Council
+Seasonal Cottage,planning,2020,1,0,42.533614,-70.785785,Salem,Metropolitan Area Planning Council
+Single Family ,planning,2020,1,0,42.52798356,-70.90612039,Salem,Metropolitan Area Planning Council
+Former Knights of Columbus,planning,2020,18,0,42.5218981,-70.89606502,Salem,Metropolitan Area Planning Council
+91 Orne Street,planning,2020,1,0,42.537105,-70.898186,Salem,Metropolitan Area Planning Council
+111 Terrace Street,planning,2020,39,0,42.328471,-71.098337,Boston,Metropolitan Area Planning Council
+11 - 26 Heron Street,planning,2020,72,0,42.269767,-71.149801,Boston,Metropolitan Area Planning Council
+"107 Prospect Street, Wakefield",planning,2020,4,0,42.503463,-71.087627,Wakefield,Metropolitan Area Planning Council
+61 Clyde Street,planning,2020,60,0,42.395893,-71.091096,Somerville,Metropolitan Area Planning Council
+8 Greenleaf Place,planning,2020,6,0,42.46681297,-71.06298053,Melrose,Metropolitan Area Planning Council
+84 Morse Street,planning,2020,0,10000,42.173449,-71.203839,Norwood,Metropolitan Area Planning Council
+Holiday Inn Express & Staybridge Suites Revere,planning,2020,0,81108,42.40060565,-70.99617367,Revere,Metropolitan Area Planning Council
+23-52 Willet Street,planning,2020,29,0,42.26973538,-71.15152462,Boston,Metropolitan Area Planning Council
+St. James Church Wellesley,projected,2020,0,100000,42.30083459,-71.3094806,Wellesley,Metropolitan Area Planning Council
+121 Madison St.,projected,2020,76,,42.42115215,-71.07025477,Malden,Metropolitan Area Planning Council
+125 Front St.,projected,2020,12,9000,42.25992441,-71.46112543,Ashland,Metropolitan Area Planning Council
+Keystone Lot,projected,2020,0,50000,42.24826745,-71.17208566,Dedham,Metropolitan Area Planning Council
+Seaside at Scituate,projected,2020,90,0,42.20302123,-70.73483926,Scituate,Metropolitan Area Planning Council
+CBD Overlay District,projected,2020,300,200000,42.46320661,-70.9488353,Lynn,Metropolitan Area Planning Council
+Avalon Hingham LLC,projected,2020,177,0,42.17480583,-70.90554278,Hingham,Metropolitan Area Planning Council
+Maison Commonwealth,projected,2020,5,0,42.35000768,-71.08337298,Boston,Metropolitan Area Planning Council
+229 Lowell Street,projected,2020,40,10000,42.39151325,-71.10656542,Somerville,Metropolitan Area Planning Council
+Mayo Group ,projected,2020,40,0,42.46340594,-70.94091771,Lynn,Metropolitan Area Planning Council
+Christian Science Plaza Revitalization Project,projected,2020,0,952000,42.34468625,-71.0837573,Boston,Metropolitan Area Planning Council
+Municipal Waste Transfer Station,projected,2020,0,12780,42.15480266,-71.02754998,Holbrook,Metropolitan Area Planning Council
+Waterfront Restaurant,projected,2020,0,10000,42.54082713,-70.88563631,Beverly,Metropolitan Area Planning Council
+DiNisco Properties,projected,2020,0,33770,42.52984804,-70.92230645,Peabody,Metropolitan Area Planning Council
+Sohier Road Self Storag,projected,2020,0,128588,42.57082783,-70.87996744,Beverly,Metropolitan Area Planning Council
+ Anchorworks,projected,2020,10,0,42.61869712,-70.67879183,Gloucester,Metropolitan Area Planning Council
+Logan Airport anticipated growth 2020,projected,2020,0,50000,42.36354048,-71.02568379,Boston,Metropolitan Area Planning Council
+Legacy Farms - Legacy Farms North,completed,2021,425,0,42.24797944,-71.50579423,Hopkinton,Metropolitan Area Planning Council
+413-415 Shirley Street,completed,2021,25,0,42.37415976,-70.97242771,Winthrop,Metropolitan Area Planning Council
+56 Fairview,completed,2021,3,0,42.38381947,-70.98917146,Winthrop,Metropolitan Area Planning Council
+Dover Road Residences,in_construction,2021,93,0,42.18362966,-71.33475646,Millis,Metropolitan Area Planning Council
+Vero,in_construction,2021,692,0,42.39927823,-71.04214373,Chelsea,Metropolitan Area Planning Council
+71 Greenwood Ave  ,in_construction,2021,28,0,42.470225,-70.910276,Swampscott,Metropolitan Area Planning Council
+Omni Hotel Seaport,in_construction,2021,0,828500,42.34802572,-71.0443587,Boston,Metropolitan Area Planning Council
+1071 Main Street,in_construction,2021,57,0,42.51808582,-71.15827893,Woburn,Metropolitan Area Planning Council
+480-482 West Broadway,in_construction,2021,18,4190,42.3356615,-71.04547008,Boston,Metropolitan Area Planning Council
+New Medford Police Headquarters,in_construction,2021,0,35000,42.41622606,-71.11016233,Medford,Metropolitan Area Planning Council
+40 Trinity Place,in_construction,2021,146,180820,42.3484986,-71.0750472,Boston,Metropolitan Area Planning Council
+Clippership Wharf (25-65 Lewis Street),in_construction,2021,478,30200,42.36713637,-71.04158154,Boston,Metropolitan Area Planning Council
+325 Main Street/New Google Building,in_construction,2021,0,376123,42.36276776,-71.08659051,Cambridge,Metropolitan Area Planning Council
+BUMC - New Inpatient Building Phase 1,in_construction,2021,0,82300,42.33488325,-71.07069408,Boston,Metropolitan Area Planning Council
+Fuller Site,in_construction,2021,170,80000,42.62352319,-70.65971515,Gloucester,Metropolitan Area Planning Council
+425 LaGrange Street,in_construction,2021,40,0,42.28128845,-71.15896646,Boston,Metropolitan Area Planning Council
+St Gabriel Monastery Student housing,in_construction,2021,660,0,42.34739091,-71.14628242,Boston,Metropolitan Area Planning Council
+54 Auburn St,in_construction,2021,12,0,42.33770811,-71.12400458,Brookline,Metropolitan Area Planning Council
+"The Congress Group, 125 Pennsylvania Ave",in_construction,2021,0,0,42.29959483,-71.4778214,Framingham,Metropolitan Area Planning Council
+458-460 Washington Street,in_construction,2021,28,0,42.34864505,-71.15868014,Boston,Metropolitan Area Planning Council
+44 North Beacon Street,in_construction,2021,30,2000,42.353516,-71.139815,Boston,Metropolitan Area Planning Council
+Siemens Walpole Facility Renovation and Expansion,in_construction,2021,0,300000,42.14988416,-71.20408681,Walpole,Metropolitan Area Planning Council
+11-19 Walley Street,in_construction,2021,38,0,42.389759,-70.998447,Boston,Metropolitan Area Planning Council
+69 A Street,in_construction,2021,0,45700,42.3419615,-71.05484436,Boston,Metropolitan Area Planning Council
+50 Rogers Street,in_construction,2021,136,0,42.36564328,-71.07889122,Cambridge,Metropolitan Area Planning Council
+Brewer Estates,in_construction,2021,7,0,42.30204971,-71.49276618,Southborough,Metropolitan Area Planning Council
+200-204 Old Colony Ave,in_construction,2021,49,9800,42.33315963,-71.0538637,Boston,Metropolitan Area Planning Council
+52 Dunham Road,in_construction,2021,0,143000,42.57894818,-70.8707093,Beverly,Metropolitan Area Planning Council
+340 West Second Street ,in_construction,2021,29,1000,42.33912557,-71.04659026,Boston,Metropolitan Area Planning Council
+238 Main Street/MIT Kendall Square Building 3,in_construction,2021,0,380500,42.36167346,-71.08471723,Cambridge,Metropolitan Area Planning Council
+314 Main Street/MIT Kendall Square Building 5,in_construction,2021,0,372000,42.36218283,-71.08667028,Cambridge,Metropolitan Area Planning Council
+1991 Massachusetts Avenue/St James Church,in_construction,2021,46,74826,42.39090316,-71.12119266,Cambridge,Metropolitan Area Planning Council
+55 West Fifth Street,in_construction,2021,50,2045,42.33938212,-71.05589385,Boston,Metropolitan Area Planning Council
+101-111 North First Street/Cambridge Crossing Building W,in_construction,2021,0,16400,42.3719463,-71.07523862,Cambridge,Metropolitan Area Planning Council
+24 Brattle Street/Abbott Building,in_construction,2021,0,71500,42.37316979,-71.1199076,Cambridge,Metropolitan Area Planning Council
+DPS Facility,in_construction,2021,0,1,42.14678503,-71.39589733,Medway,Metropolitan Area Planning Council
+110 Royall Street- Hotel,in_construction,2021,0,130000,42.20714601,-71.12760819,Canton,Metropolitan Area Planning Council
+Deer Run Holliston,in_construction,2021,7,0,42.17217703,-71.47839669,Holliston,Metropolitan Area Planning Council
+Bethel Baptist Church,in_construction,2021,0,23436,42.30717901,-71.07731926,Boston,Metropolitan Area Planning Council
+Brookview House II (1047-1051 Blue Hill Ave),in_construction,2021,16,0,42.28865892,-71.08967628,Boston,Metropolitan Area Planning Council
+Village at Bedford Woods,in_construction,2021,56,0,42.52381054,-71.24906295,Bedford,Metropolitan Area Planning Council
+Deer Brook Estates,in_construction,2021,6,0,42.01859797,-71.44911433,Wrentham,Metropolitan Area Planning Council
+730-750 Main Street,in_construction,2021,0,204089,42.36293149,-71.09600007,Cambridge,Metropolitan Area Planning Council
+181 Morgan Avenue/Cambridge Crossing Building Q1,in_construction,2021,0,18400,42.37215015,-71.07577296,Cambridge,Metropolitan Area Planning Council
+455 Grand Union Blvd,in_construction,2021,0,267300,42.39356039,-71.08009104,Somerville,Metropolitan Area Planning Council
+17-25 Murdock Street,in_construction,2021,22,0,42.39569003,-71.10905912,Somerville,Metropolitan Area Planning Council
+Assembly Row: Block 8,in_construction,2021,500,26500,42.39287384,-71.07819252,Somerville,Metropolitan Area Planning Council
+Haymarket Hotel - Parcel 9,in_construction,2021,0,124600,42.3617413,-71.05615938,Boston,Metropolitan Area Planning Council
+Orient Heights Redevelopment Project,in_construction,2021,331,0,42.39256266,-71.00879994,Boston,Metropolitan Area Planning Council
+151 Granite St,in_construction,2021,32,0,42.24544184,-71.00684205,Quincy,Metropolitan Area Planning Council
+571 Revere Street,in_construction,2021,51,0,42.41857279,-70.98923369,Revere,Metropolitan Area Planning Council
+90 Ocean Ave,in_construction,2021,75,0,42.40337367,-70.99145871,Revere,Metropolitan Area Planning Council
+Marriott Springhill Suites Hotel - Waterfront Square,in_construction,2021,0,5000,42.41330937,-70.99088111,Revere,Metropolitan Area Planning Council
+10 Fan Pier Boulevard (Parcel E),in_construction,2021,0,300000,42.35376386,-71.04491987,Boston,Metropolitan Area Planning Council
+22 Hurley Street/First Street Assemblage,in_construction,2021,18,0,42.36782271,-71.07820593,Cambridge,Metropolitan Area Planning Council
+North Quincy MBTA Redevelopment (The Abby),in_construction,2021,610,50000,42.27601492,-71.02962485,Quincy,Metropolitan Area Planning Council
+Kenmore Square Redevelopment,in_construction,2021,0,272500,42.34920938,-71.09661047,Boston,Metropolitan Area Planning Council
+7INK,in_construction,2021,180,0,42.34544866,-71.0617206,Boston,Metropolitan Area Planning Council
+Bear Hill Village,in_construction,2021,147,0,42.13285908,-71.49589109,Milford,Metropolitan Area Planning Council
+Boston University Goldman School of Dental Medicine,in_construction,2021,0,84200,42.33627149,-71.07012052,Boston,Metropolitan Area Planning Council
+112 Shawmut Avenue - Planned Development Area,in_construction,2021,139,70980,42.34658779,-71.06545196,Boston,Metropolitan Area Planning Council
+The Chandlery,planning,2021,114,6590,42.33870501,-71.05688506,Boston,Metropolitan Area Planning Council
+Four Corners Plaza,planning,2021,31,9200,42.30624865,-71.0679906,Boston,Metropolitan Area Planning Council
+70 Leo M. Birmingham Parkway,planning,2021,82,0,42.35913464,-71.14679366,Boston,Metropolitan Area Planning Council
+The Huntington,planning,2021,446,21500,42.34217067,-71.08517161,Boston,Metropolitan Area Planning Council
+114 Orleans Street,planning,2021,23,0,42.36985866,-71.03679063,Boston,Metropolitan Area Planning Council
+1199-1203 Blue Hill Avenue,planning,2021,32,2500,42.28335247,-71.09201762,Boston,Metropolitan Area Planning Council
+105 West First Street,planning,2021,0,264600,42.34302666,-71.05303662,Boston,Metropolitan Area Planning Council
+1241 Boylston Street,planning,2021,0,105244,42.34567669,-71.09514058,Boston,Metropolitan Area Planning Council
+135 Wells Avenue,planning,2021,334,6000,42.29177877,-71.19494495,Newton,Metropolitan Area Planning Council
+District 9 at 61 North Beacon Street,planning,2021,71,0,42.35435856,-71.14050941,Boston,Metropolitan Area Planning Council
+254 Spencer Ave - The Spencer Flats,planning,2021,8,0,42.40100712,-71.01988266,Chelsea,Metropolitan Area Planning Council
+Boston Childrens Hospital - Clinical Building,planning,2021,0,44500,42.33616888,-71.10550812,Boston,Metropolitan Area Planning Council
+225 Industrial Road,planning,2021,0,24000,42.07771234,-71.36132769,Wrentham,Metropolitan Area Planning Council
+31 & 39 Newbury St,planning,2021,72,0,42.28130949,-71.03804065,Quincy,Metropolitan Area Planning Council
+Swains Pond Ave,planning,2021,44,0,42.44602536,-71.04528718,Melrose,Metropolitan Area Planning Council
+176-182 Broadway,planning,2021,19,3297,42.38872857,-71.08678556,Somerville,Metropolitan Area Planning Council
+197-201 Green Street,planning,2021,23,6000,42.30960194,-71.10543364,Boston,Metropolitan Area Planning Council
+Wellington at 1301,planning,2021,39,1500,42.27931034,-71.09279089,Boston,Metropolitan Area Planning Council
+171 Atlantic Rd (Ocean View Inn),planning,2021,29,0,42.60225563,-70.6362254,Gloucester,Metropolitan Area Planning Council
+212 Stuart Street,planning,2021,126,3000,42.35043602,-71.06816577,Boston,Metropolitan Area Planning Council
+100-110 Lincoln Street,planning,2021,32,0,42.35839055,-71.14243972,Boston,Metropolitan Area Planning Council
+11 Faneuil Street,planning,2021,41,0,42.35528835,-71.150417,Boston,Metropolitan Area Planning Council
+139-149 Washington St,planning,2021,248,0,42.34679716,-71.14508438,Boston,Metropolitan Area Planning Council
+205 Maverick Street,planning,2021,49,3237,42.36880263,-71.03625737,Boston,Metropolitan Area Planning Council
+5 Forge Parkway,planning,2021,0,34000,42.08656754,-71.43725408,Franklin,Metropolitan Area Planning Council
+Randall Road Subdivision,planning,2021,4,0,42.51761223,-71.12474334,Reading,Metropolitan Area Planning Council
+345 Medford Street,planning,2021,20,4000,42.3886961,-71.09636047,Somerville,Metropolitan Area Planning Council
+350-360 Medford Street,planning,2021,82,24000,42.38872831,-71.0971772,Somerville,Metropolitan Area Planning Council
+91 Marshall Street,planning,2021,24,7800,42.38869867,-71.09565725,Somerville,Metropolitan Area Planning Council
+Longwood Research Institute (formerly LNRC),planning,2021,0,440000,42.33914599,-71.10504998,Boston,Metropolitan Area Planning Council
+Forest Ridge,planning,2021,12,0,42.21099353,-71.51185346,Hopkinton,Metropolitan Area Planning Council
+45 Townsend Street,planning,2021,300,2200,42.318599,-71.092765,Boston,Metropolitan Area Planning Council
+87-93  West Broadway,planning,2021,65,9000,42.34168673,-71.05497837,Boston,Metropolitan Area Planning Council
+Airport Road Housing,planning,2021,30,0,42.45270603,-71.27159128,Lincoln,Metropolitan Area Planning Council
+425 Border Street,planning,2021,16,0,42.38178835,-71.04013015,Boston,Metropolitan Area Planning Council
+250 Centre Street - Jackson Square Site III,planning,2021,156,2400,42.3224,-71.0996,Boston,Metropolitan Area Planning Council
+15-17 Walden St,planning,2021,16,0,42.38002983,-70.98684246,Winthrop,Metropolitan Area Planning Council
+75-85 Liverpool Street,planning,2021,22,800,42.37196204,-71.04085143,Boston,Metropolitan Area Planning Council
+620 Broadway,planning,2021,11,1200,42.39877657,-71.10968794,Somerville,Metropolitan Area Planning Council
+287 Maverick Street,planning,2021,38,2180,42.36727403,-71.03295807,Boston,Metropolitan Area Planning Council
+40 Mount Hood Road,planning,2021,151,24050,42.341816,-71.143574,Boston,Metropolitan Area Planning Council
+90 School Street Addition,planning,2021,9,0,42.24357523,-71.00401916,Quincy,Metropolitan Area Planning Council
+30 Thorn Street,planning,2021,45,0,42.26441164,-71.10326057,Boston,Metropolitan Area Planning Council
+40 Rugg Road,planning,2021,261,2700,42.35579466,-71.13563762,Boston,Metropolitan Area Planning Council
+101-105 Washington Street,planning,2021,70,14000,42.34478598,-71.14430757,Boston,Metropolitan Area Planning Council
+280-290 Warren St,planning,2021,95,11334,42.32104837,-71.08149652,Boston,Metropolitan Area Planning Council
+5 Washington Street,planning,2021,108,12500,42.34245502,-71.14004464,Boston,Metropolitan Area Planning Council
+500 Medford St,planning,2021,4,2593,42.3957472,-71.10348337,Somerville,Metropolitan Area Planning Council
+365 Newport Avenue,planning,2021,10,0,42.26455119,-71.01905324,Quincy,Metropolitan Area Planning Council
+450 American Legion Parkway,planning,2021,31,0,42.42032203,-71.00299682,Revere,Metropolitan Area Planning Council
+246-248 Dorchester Avenue,planning,2021,0,86000,42.33976192,-71.0567254,Boston,Metropolitan Area Planning Council
+OSRD Plan off Thaxton Road and Grover Street,planning,2021,4,0,42.59023987,-70.85907343,Beverly,Metropolitan Area Planning Council
+39 Crosby Drive,planning,2021,0,72303,42.51159599,-71.24199588,Bedford,Metropolitan Area Planning Council
+Birch Hill,planning,2021,23,0,42.56547961,-71.02728976,Peabody,Metropolitan Area Planning Council
+Hemisphere Development,planning,2021,120,0,42.52888891,-70.93813292,Peabody,Metropolitan Area Planning Council
+115 Main Street,planning,2021,26,5000,42.43206722,-71.45500212,Maynard,Metropolitan Area Planning Council
+154-156 Northboro Rd.,planning,2021,0,23069,42.313743,-71.574987,Southborough,Metropolitan Area Planning Council
+Salmon Village – The Willows at Medway,planning,2021,225,11475,42.13595215,-71.41218144,Medway,Metropolitan Area Planning Council
+41-51 Walnut Park,planning,2021,42,0,42.31504864,-71.09602063,Boston,Metropolitan Area Planning Council
+Carleton Willard Village Expansion,planning,2021,12,0,42.49761247,-71.2576158,Bedford,Metropolitan Area Planning Council
+Beverly Police Station,planning,2021,0,300000,42.55640175,-70.88587247,Beverly,Metropolitan Area Planning Council
+1043-1059 Cambridge Street/University Monument Site,planning,2021,18,4564,42.37318187,-71.09478491,Cambridge,Metropolitan Area Planning Council
+95-99 Elmwood Street,planning,2021,34,500,42.39799333,-71.12862556,Cambridge,Metropolitan Area Planning Council
+161 First Street,planning,2021,0,30087,42.36556969,-71.07840293,Cambridge,Metropolitan Area Planning Council
+41 LaGrange,planning,2021,126,0,42.35179303,-71.06404122,Boston,Metropolitan Area Planning Council
+16-18 Eliot St.,planning,2021,15,0,42.37205606,-71.1213788,Cambridge,Metropolitan Area Planning Council
+"Medfield Green, 41 Dale Street",planning,2021,36,0,42.18958279,-71.31455967,Medfield,Metropolitan Area Planning Council
+869 Washington Street,planning,2021,56,0,42.16015064,-71.14249254,Canton,Metropolitan Area Planning Council
+2 Meetinghouse Rd,planning,2021,5,0,42.17734766,-71.11364279,Canton,Metropolitan Area Planning Council
+"Innovation Point (GE HQ) - Phase 2 ""South Point"" ",planning,2021,0,300000,42.34901763,-71.05168817,Boston,Metropolitan Area Planning Council
+Indian Lane Flexible Subdivision,planning,2021,8,0,42.15420854,-71.09485813,Canton,Metropolitan Area Planning Council
+14 Westville Street,planning,2021,14,0,42.30015136,-71.07180664,Boston,Metropolitan Area Planning Council
+Bed Rock Geneva (185-191 Geneva Ave),planning,2021,27,0,42.30489278,-71.07591371,Boston,Metropolitan Area Planning Council
+101 Condor Street,planning,2021,18,8650,42.38244626,-71.03625921,Boston,Metropolitan Area Planning Council
+191-195 Bowdoin Street,planning,2021,41,6047,42.30500604,-71.06914842,Boston,Metropolitan Area Planning Council
+ 1120-1132 Washington Street,planning,2021,57,0,42.272977,-71.069441,Boston,Metropolitan Area Planning Council
+3 Aspinwall Road,planning,2021,34,0,42.29204064,-71.07250368,Boston,Metropolitan Area Planning Council
+360 Main Street - MMTV Building,planning,2021,42,6893,42.45261776,-71.06717819,Melrose,Metropolitan Area Planning Council
+Hotel and Restaurant,planning,2021,0,24443,42.42396332,-71.17669482,Arlington,Metropolitan Area Planning Council
+57 JFK St.,planning,2021,0,18400,42.37214221,-71.1209134,Cambridge,Metropolitan Area Planning Council
+Campus at Crosby,planning,2021,0,300000,42.51368863,-71.24516094,Bedford,Metropolitan Area Planning Council
+12-16 Essex Street,planning,2021,14,1590,42.45612226,-71.06517183,Melrose,Metropolitan Area Planning Council
+17 Perry Drive,planning,2021,0,10000,42.10449071,-71.24671687,Foxborough,Metropolitan Area Planning Council
+15-19 Congress Street,planning,2021,0,54350,42.35829943,-71.0568111,Boston,Metropolitan Area Planning Council
+Greenway Planning - Dock Square Garage,planning,2021,209,0,42.36150755,-71.05531267,Boston,Metropolitan Area Planning Council
+Cambria Hotel Somerville,planning,2021,0,98000,42.38346898,-71.10575514,Somerville,Metropolitan Area Planning Council
+5 Fremont Street,planning,2021,22,3300,42.37631019,-70.98578261,Winthrop,Metropolitan Area Planning Council
+75 Dudley Street,planning,2021,20,1580,42.32879723,-71.08629921,Boston,Metropolitan Area Planning Council
+850 North Shore Road,planning,2021,18,0,42.42480353,-70.98617818,Revere,Metropolitan Area Planning Council
+10 Taber st,planning,2021,45,1830,42.33017293,-71.08290612,Boston,Metropolitan Area Planning Council
+211 Condor Street,planning,2021,12,0,42.38246206,-71.03272184,Boston,Metropolitan Area Planning Council
+1 Newcomb Place,planning,2021,23,0,42.33439228,-71.07881369,Boston,Metropolitan Area Planning Council
+Bartlett Station (Building A),planning,2021,42,37868,42.32755328,-71.08747449,Boston,Metropolitan Area Planning Council
+125 Warren Street,planning,2021,28,0,42.32611634,-71.08356828,Boston,Metropolitan Area Planning Council
+Northeastern: EXP,planning,2021,0,350000,42.33717452,-71.08765915,Boston,Metropolitan Area Planning Council
+Ben Franklin Institute of Technology,planning,2021,0,85000,42.3315781,-71.08054036,Boston,Metropolitan Area Planning Council
+124-126 Warren Street,planning,2021,18,989,42.32640131,-71.08299015,Boston,Metropolitan Area Planning Council
+E+ Highland Street (273-287 Highland Street),planning,2021,23,860,42.32402021,-71.09651044,Boston,Metropolitan Area Planning Council
+Simmons Living & Learning Center,planning,2021,0,134000,42.33887466,-71.10122988,Boston,Metropolitan Area Planning Council
+72 Burbank St,planning,2021,32,0,42.34438655,-71.08921818,Boston,Metropolitan Area Planning Council
+3326 Washington Street,planning,2021,47,2729,42.30955188,-71.10421108,Boston,Metropolitan Area Planning Council
+Hospital Site - Woodland Road,planning,2021,200,0,42.45125592,-71.08842339,Stoneham,Metropolitan Area Planning Council
+Cohasset Plaza - Third Retail Building,planning,2021,0,30000,42.23438833,-70.82095317,Cohasset,Metropolitan Area Planning Council
+40 Centre Street,planning,2021,40,0,42.34252644,-71.12439937,Brookline,Metropolitan Area Planning Council
+2 Hardy Street,projected,2021,6,0,42.54621158,-70.88356545,Beverly,Metropolitan Area Planning Council
+"20, 30, & 40 Webster Ave (Hickory Hill Way)",projected,2021,9,0,42.56660552,-70.8202395,Beverly,Metropolitan Area Planning Council
+Vitality Senior Living,projected,2021,118,6000,42.57734986,-70.87146794,Beverly,Metropolitan Area Planning Council
+55 Wheeler Street,in_construction,2022,526,0,42.39059747,-71.14453393,Cambridge,Metropolitan Area Planning Council
+125 Amory Street ,in_construction,2022,353,0,42.31937865,-71.10089064,Boston,Metropolitan Area Planning Council
+Broadway Theater Redevelopment,in_construction,2022,42,1350,42.33686776,-71.04709069,Boston,Metropolitan Area Planning Council
+State Street HQ (One Congress Tower),in_construction,2022,0,1300000,42.36250872,-71.06010518,Boston,Metropolitan Area Planning Council
+Boston University Data Science Center,in_construction,2022,0,350000,42.34998801,-71.10313371,Boston,Metropolitan Area Planning Council
+50 Tufts Street,in_construction,2022,14,0,42.38198296,-71.08872477,Somerville,Metropolitan Area Planning Council
+65 - 162 Taylor Farm Road,in_construction,2022,11,0,42.47279118,-71.50045984,Boxborough,Metropolitan Area Planning Council
+Nadia Estates,in_construction,2022,36,0,42.09044933,-71.2317997,Foxborough,Metropolitan Area Planning Council
+Legacy Farms -- The Trails in Hopkinton,in_construction,2022,180,0,42.25142109,-71.51637101,Hopkinton,Metropolitan Area Planning Council
+Wyman Village,in_construction,2022,20,0,42.06417996,-71.20226305,Foxborough,Metropolitan Area Planning Council
+Highland Ridge,in_construction,2022,8,0,42.07397363,-71.26194277,Foxborough,Metropolitan Area Planning Council
+50 Cambridgepark Drive,in_construction,2022,299,6992,42.39419267,-71.14375486,Cambridge,Metropolitan Area Planning Council
+Ropewalk Complex,in_construction,2022,97,12000,42.3755731,-71.05552925,Boston,Metropolitan Area Planning Council
+107 First Street/First Street Assemblage,in_construction,2022,118,14800,42.36765173,-71.07779696,Cambridge,Metropolitan Area Planning Council
+450 Water Street/Cambridge Crossing Building H,in_construction,2022,0,365110,42.37251923,-71.07210026,Cambridge,Metropolitan Area Planning Council
+350 Water Street - Cambridge Crossing Building G,in_construction,2022,0,450895,42.37253931,-71.0729309,Cambridge,Metropolitan Area Planning Council
+21 Revere Beach Blvd / 20-50 Ocean Ave,in_construction,2022,200,5300,42.40341788,-70.99077937,Revere,Metropolitan Area Planning Council
+115 Winthrop Square,in_construction,2022,387,813081,42.35453135,-71.0571291,Boston,Metropolitan Area Planning Council
+36-40 Sprague,planning,2022,247,0,42.23589706,-71.13526466,Boston,Metropolitan Area Planning Council
+30 Penniman Road,planning,2022,46,0,42.35534309,-71.13638413,Boston,Metropolitan Area Planning Council
+Commons at Weiss Farm,planning,2022,124,0,42.47447876,-71.08532553,Stoneham,Metropolitan Area Planning Council
+Sunrise Senior Living ,planning,2022,85,0,42.35623416,-71.19045,Newton,Metropolitan Area Planning Council
+Haywood House,planning,2022,55,0,42.32069238,-71.20938854,Newton,Metropolitan Area Planning Council
+1180 Boylston,planning,2022,45,5560,42.32339162,-71.16325018,Brookline,Metropolitan Area Planning Council
+256 Dorchester Street,planning,2022,32,7835,42.33238864,-71.05144059,Boston,Metropolitan Area Planning Council
+Highlands Village,planning,2022,96,0,42.18875136,-70.98584774,Braintree,Metropolitan Area Planning Council
+Jacobs Ladder Condominiums,planning,2022,65,0,42.4421288,-70.96736671,Revere,Metropolitan Area Planning Council
+McDonald Road Estates,planning,2022,26,,42.5862754,-71.17423466,Wilmington,Metropolitan Area Planning Council
+Market Forge,planning,2022,591,7300,42.40224609,-71.053448,Everett,Metropolitan Area Planning Council
+2 H Street,planning,2022,135,6500,42.33763775,-71.04101614,Boston,Metropolitan Area Planning Council
+Park Place Wrentham,planning,2022,92,0,42.08697456,-71.35164041,Wrentham,Metropolitan Area Planning Council
+29-31 Newcomb Street,planning,2022,39,0,42.25237325,-70.99895245,Quincy,Metropolitan Area Planning Council
+Common Allbright,planning,2022,80,0,42.35770769,-71.1291961,Boston,Metropolitan Area Planning Council
+29-33 Newport Ave,planning,2022,107,0,42.27348078,-71.0290675,Quincy,Metropolitan Area Planning Council
+31-35 Wyoming Ave,planning,2022,36,0,42.45206595,-71.06893429,Melrose,Metropolitan Area Planning Council
+99 Washington Street,planning,2022,141,1000,42.44227227,-71.07149472,Melrose,Metropolitan Area Planning Council
+4000 Mystic Valley Parkway,planning,2022,400,0,42.40457941,-71.08818998,Medford,Metropolitan Area Planning Council
+970 Fellsway ,planning,2022,289,0,42.415104,-71.085437,Medford,Metropolitan Area Planning Council
+280 Mystic Ave,planning,2022,378,0,42.40544851,-71.10069221,Medford,Metropolitan Area Planning Council
+Beth Israel Deaconess Medical Center New Inpatient Building,planning,2022,0,345000,42.33745245,-71.10966636,Boston,Metropolitan Area Planning Council
+Taj Hotel,planning,2022,0,5200,42.35280664,-71.07154898,Boston,Metropolitan Area Planning Council
+160 Washington Street,planning,2022,20,12000,42.38011599,-71.08885644,Somerville,Metropolitan Area Planning Council
+254 Lynnway,planning,2022,331,0,42.45920009,-70.94599441,Lynn,Metropolitan Area Planning Council
+41 North Main St,planning,2022,60,0,42.24899702,-71.3697287,Sherborn,Metropolitan Area Planning Council
+Bogan Estates,planning,2022,3,0,42.04303307,-71.44159899,Franklin,Metropolitan Area Planning Council
+117-127 Heath St. Condos (Eblana Brewery),planning,2022,83,0,42.32683185,-71.10344618,Boston,Metropolitan Area Planning Council
+54 - 56 Winter Street,planning,2022,18,0,42.24111137,-70.97912795,Quincy,Metropolitan Area Planning Council
+400 West Broadway,planning,2022,36,5000,42.33727255,-71.04801309,Boston,Metropolitan Area Planning Council
+319-327 Chelsea Street,planning,2022,38,0,42.37746455,-71.02940927,Boston,Metropolitan Area Planning Council
+30 Alston Street,planning,2022,6,0,42.38165871,-71.08917618,Somerville,Metropolitan Area Planning Council
+1857-1859 Dorchester Ave,planning,2022,20,1659,42.28750092,-71.06424866,Boston,Metropolitan Area Planning Council
+438 Waverly St,planning,2022,2,2500,42.27624523,-71.41757335,Framingham,Metropolitan Area Planning Council
+249 Corey Road,planning,2022,34,0,42.34469369,-71.13713455,Boston,Metropolitan Area Planning Council
+172 South Street,planning,2022,12,0,42.24405345,-70.99073303,Quincy,Metropolitan Area Planning Council
+152-154 Liverpool Street,planning,2022,23,3000,42.37343673,-71.04017715,Boston,Metropolitan Area Planning Council
+277-279 Border Street,planning,2022,18,510,42.37736446,-71.03964352,Boston,Metropolitan Area Planning Council
+The Boston Garden - The Hub at Causeway - Phase II,planning,2022,497,708000,42.3658,-71.0621,Boston,Metropolitan Area Planning Council
+50-56 Leo Birmingham Parkway,planning,2022,49,0,42.35996621,-71.14643359,Boston,Metropolitan Area Planning Council
+544 Washington Street,planning,2022,37,2000,42.34914914,-71.16388807,Boston,Metropolitan Area Planning Council
+Washington Street Plaza (15 Washington Street),planning,2022,270,49000,42.34271459,-71.14042948,Boston,Metropolitan Area Planning Council
+144 Addison Street,planning,2022,230,0,42.385835,-71.016846,Boston,Metropolitan Area Planning Council
+Chinese Consolidated Benevolent Association - Planned Development Area,planning,2022,302,14200,42.34644866,-71.06499061,Boston,Metropolitan Area Planning Council
+11 Dana Ave,planning,2022,24,300,42.25401809,-71.12489195,Boston,Metropolitan Area Planning Council
+200 Moody Street,planning,2022,16,0,42.37250752,-71.23639763,Waltham,Metropolitan Area Planning Council
+182 Washington Street,planning,2022,9,4500,42.37968932,-71.09027112,Somerville,Metropolitan Area Planning Council
+190-209 West Second,planning,2022,97,4000,42.3406359,-71.04930187,Boston,Metropolitan Area Planning Council
+Union Square Revitalization: 5.2 & 5.3,planning,2022,35,44143,42.37972329,-71.09324596,Somerville,Metropolitan Area Planning Council
+350 Boylston Street,planning,2022,0,221230,42.35150291,-71.07099371,Boston,Metropolitan Area Planning Council
+6 Glover Court,planning,2022,34,0,42.3309759,-71.05636086,Boston,Metropolitan Area Planning Council
+400 Dorchester Street,planning,2022,35,2535,42.32995318,-71.05668608,Boston,Metropolitan Area Planning Council
+603 Dorchester Ave,planning,2022,24,2012,42.32900433,-71.05710312,Boston,Metropolitan Area Planning Council
+The Parkway Apartments,planning,2022,258,0,42.26847709,-71.17207962,Boston,Metropolitan Area Planning Council
+66 Mayor McGrath ,planning,2022,46,0,42.25136186,-70.998017,Quincy,Metropolitan Area Planning Council
+Quincy Hospital Residential Development,planning,2022,465,0,42.25091061,-71.01392649,Quincy,Metropolitan Area Planning Council
+Harvard University (Allston): HBS Faculty & Administrative Office Building,planning,2022,0,110000,42.36538906,-71.12412609,Boston,Metropolitan Area Planning Council
+St. Elizabeth's Medical Center Parking Garage,planning,2022,0,0,42.34773495,-71.1485202,Boston,Metropolitan Area Planning Council
+Wellesley Square Redevelopment - Tailby and Raillroad Avenue parking lots,planning,2022,90,9200,42.29768446,-71.29482824,Wellesley,Metropolitan Area Planning Council
+"700, 750, & 800 Massachusetts Ave",planning,2022,100,0,42.47809544,-71.51848159,Boxborough,Metropolitan Area Planning Council
+6 Stack Street,planning,2022,0,924,42.38001246,-71.07317764,Boston,Metropolitan Area Planning Council
+Uncas Ave,planning,2022,18,0,42.08002577,-71.38901857,Franklin,Metropolitan Area Planning Council
+Granite Hill - 984 & 996 Massachusetts Avenue and 38 Sara's Way,planning,2022,12,0,42.48277196,-71.52457726,Boxborough,Metropolitan Area Planning Council
+29 Wall Street,planning,2022,50,4600,42.06341794,-71.24667533,Foxborough,Metropolitan Area Planning Council
+142-144 Old Colony Ave,planning,2022,19,1116,42.33491351,-71.05490797,Boston,Metropolitan Area Planning Council
+1440 Main Street PRD,planning,2022,36,0,42.45474009,-71.39943896,Concord,Metropolitan Area Planning Council
+21-35 West Second Street,planning,2022,55,2600,42.34313394,-71.0560433,Boston,Metropolitan Area Planning Council
+267 Old Colony Ave,planning,2022,55,8009,42.33112765,-71.05325054,Boston,Metropolitan Area Planning Council
+3368 Washington Street,planning,2022,85,18000,42.30883941,-71.10470801,Boston,Metropolitan Area Planning Council
+41 Linskey Way,planning,2022,0,16200,42.36499115,-71.08033164,Cambridge,Metropolitan Area Planning Council
+263 Monsignor O'Brien Highway/Somerbridge Hotel,planning,2022,0,23221,42.37391311,-71.0812811,Cambridge,Metropolitan Area Planning Council
+288 Harrison Ave,planning,2022,85,0,42.34717438,-71.06247631,Boston,Metropolitan Area Planning Council
+765 East Third Street,planning,2022,25,0,42.33650426,-71.028851,Boston,Metropolitan Area Planning Council
+171 Veterans of foreign wars parkway,planning,2022,10,0,42.41080274,-70.99689371,Revere,Metropolitan Area Planning Council
+605-609 Concord Ave/BoA site,planning,2022,49,4100,42.38912129,-71.14487767,Cambridge,Metropolitan Area Planning Council
+951-959A Dorchester Ave,planning,2022,38,6670,42.3181705,-71.05694704,Boston,Metropolitan Area Planning Council
+151 Spencer Street,planning,2022,19,0,42.29173884,-71.07517354,Boston,Metropolitan Area Planning Council
+9 Leyland Street ,planning,2022,43,0,42.32083426,-71.07114919,Boston,Metropolitan Area Planning Council
+747 Cambridge Street/Polish Club,planning,2022,9,1500,42.37235257,-71.08904814,Cambridge,Metropolitan Area Planning Council
+17 Glenwood Ave,planning,2022,6,0,42.07061061,-71.25465227,Foxborough,Metropolitan Area Planning Council
+230 Sprague Street,planning,2022,2,0,42.22943841,-71.15062813,Dedham,Metropolitan Area Planning Council
+151 North First Street/Cambridge Crossing Building I,planning,2022,475,26036,42.37235087,-71.07409466,Cambridge,Metropolitan Area Planning Council
+Onyx Hotel Addition,planning,2022,0,40725,42.36426997,-71.06136142,Boston,Metropolitan Area Planning Council
+Post Road Development,planning,2022,200,0,42.41495345,-70.99028853,Revere,Metropolitan Area Planning Council
+40-50 Warren St,planning,2022,25,12000,42.32917701,-71.08312558,Boston,Metropolitan Area Planning Council
+Lenox Housing Renovations,planning,2022,0,0,42.33727276,-71.08244287,Boston,Metropolitan Area Planning Council
+2 Ford Street,planning,2022,27,1630,42.38735964,-71.00803229,Boston,Metropolitan Area Planning Council
+12- 28 Lansdown St (Fenway Theater),planning,2022,0,91500,42.34690848,-71.09503531,Boston,Metropolitan Area Planning Council
+301-303 Border Street ,planning,2022,64,1200,42.37784457,-71.03972825,Boston,Metropolitan Area Planning Council
+Washington Village (Phase I),planning,2022,214,20500,42.33162778,-71.05345642,Boston,Metropolitan Area Planning Council
+Boston Teacher's Union Building Replacement Project,planning,2022,0,52469,42.3220299,-71.04718372,Boston,Metropolitan Area Planning Council
+21-29 Beale Street,planning,2022,75,9000,42.26722913,-71.01734648,Quincy,Metropolitan Area Planning Council
+73 Liberty Street,planning,2022,48,0,42.23921784,-71.00766375,Quincy,Metropolitan Area Planning Council
+1252-1270 Boylston Street,planning,2022,451,15000,42.34477494,-71.09586129,Boston,Metropolitan Area Planning Council
+99-105 Fairmount Ave,planning,2022,47,2540,42.25395777,-71.11985559,Boston,Metropolitan Area Planning Council
+Faulkner Hospital Inpatient Addition,planning,2022,0,0,42.30149074,-71.12828251,Boston,Metropolitan Area Planning Council
+50 Stedman Street,planning,2022,21,0,42.30341238,-71.10792808,Boston,Metropolitan Area Planning Council
+Hemenway Farm Subdivision,planning,2022,29,0,42.41602693,-71.54632395,Stow,Metropolitan Area Planning Council
+80 East Berkeley Street,planning,2022,0,308000,42.3442183,-71.06610785,Boston,Metropolitan Area Planning Council
+Boston Chinese Evangelical Church - Planned Development Area,planning,2022,72,2000,42.34624864,-71.06570061,Boston,Metropolitan Area Planning Council
+Mattapan Station Mixed-Use Development,planning,2022,144,10000,42.26748915,-71.09182352,Boston,Metropolitan Area Planning Council
+150 River Street,planning,2022,30,0,42.27130058,-71.07777937,Boston,Metropolitan Area Planning Council
+775 Morton Street,planning,2022,27,0,42.28302664,-71.08923842,Boston,Metropolitan Area Planning Council
+Boston University Academic/Administrative Building,projected,2022,0,60000,42.35001176,-71.09969815,Boston,Metropolitan Area Planning Council
+Logan Express Parking Garage,projected,2022,0,0,42.366,-71.0196,Boston,Metropolitan Area Planning Council
+Boston University Academic Building Addition,projected,2022,0,50000,42.34900367,-71.10246155,Boston,Metropolitan Area Planning Council
+"Mayrock, 50 Peter Kristoff Way",projected,2022,56,0,42.19275455,-71.3217115,Medfield,Metropolitan Area Planning Council
+Chamberlain Street-Whalen Rd. Subdivision,in_construction,2023,32,0,42.21344468,-71.53052182,Hopkinton,Metropolitan Area Planning Council
+Chapman's Corner subdivision,in_construction,2023,34,0,42.55663167,-70.85197943,Beverly,Metropolitan Area Planning Council
+1 Broadway Redevelopment and Expansion,in_construction,2023,295,348000,42.36266266,-71.08303683,Cambridge,Metropolitan Area Planning Council
+Paul Revere Heritage Site,in_construction,2023,272,12000,42.15585769,-71.15182632,Canton,Metropolitan Area Planning Council
+Fenway Center Turnpike Parcel (Phase II),in_construction,2023,0,720000,42.34783532,-71.09903776,Boston,Metropolitan Area Planning Council
+2 Earle Street (Boynton Yards Phase 1: Bldg 2),in_construction,2023,0,235000,42.37489129,-71.09106219,Somerville,Metropolitan Area Planning Council
+New Volpe Transportation Research Center,in_construction,2023,0,400000,42.36348833,-71.08449081,Cambridge,Metropolitan Area Planning Council
+Coolidge Residences at Brookline,planning,2023,299,0,42.34299249,-71.12091059,Brookline,Metropolitan Area Planning Council
+Beachcomber Redevelopment,planning,2023,0,7000,42.27607852,-71.00865245,Quincy,Metropolitan Area Planning Council
+BU Life Sciences and Engineering,planning,2023,0,149500,42.34881424,-71.10133414,Boston,Metropolitan Area Planning Council
+150 Kneeland ,planning,2023,0,96500,42.34997165,-71.05813988,Boston,Metropolitan Area Planning Council
+BIDMC New Inpatient Building,planning,2023,0,325000,42.33733037,-71.11032191,Boston,Metropolitan Area Planning Council
+Old Colony Phase III B  - C,planning,2023,163,0,42.33162235,-71.04972173,Boston,Metropolitan Area Planning Council
+1515 Commonwealth Ave,planning,2023,330,0,42.34649834,-71.14187599,Boston,Metropolitan Area Planning Council
+11 - 17 Newbury Street,planning,2023,24,0,42.28177788,-71.03726007,Quincy,Metropolitan Area Planning Council
+85 - 105 Myrtle Street,planning,2023,43,0,42.27891261,-71.03703427,Quincy,Metropolitan Area Planning Council
+365 Western Ave,planning,2023,65,0,42.36314984,-71.13790548,Boston,Metropolitan Area Planning Council
+1970 Dorchester Avenue,planning,2023,56,6265,42.28340901,-71.06457335,Boston,Metropolitan Area Planning Council
+Northland Needham Street Development,planning,2023,800,295000,42.3078817,-71.21638044,Newton,Metropolitan Area Planning Council
+New Quincy Center Redevelopment,planning,2023,1210,2710000,42.248685,-71.0024921,Quincy,Metropolitan Area Planning Council
+J.J. Carroll Redevelopment,planning,2023,144,1200,42.34301283,-71.15245088,Boston,Metropolitan Area Planning Council
+UHomes / 90 Antwerp Street,planning,2023,20,0,42.3611767,-71.13946969,Boston,Metropolitan Area Planning Council
+218-220 Old Colony Ave,planning,2023,32,1700,42.33277712,-71.05331082,Boston,Metropolitan Area Planning Council
+380 Main Street/MIT Kendall Square Building 6,planning,2023,0,13200,42.36230888,-71.08751252,Cambridge,Metropolitan Area Planning Council
+Lynnway Mart Redevelopment,planning,2023,550,10000,42.44750849,-70.96182499,Lynn,Metropolitan Area Planning Council
+Top Golf Development - 777 Dedham Street,planning,2023,0,65000,42.19508642,-71.15184663,Canton,Metropolitan Area Planning Council
+Lynn Gear Works Redevelopment,planning,2023,1260,7800,42.45111293,-70.97248159,Lynn,Metropolitan Area Planning Council
+270 Talbot Avenue,planning,2023,21,2700,42.29134586,-71.07536625,Boston,Metropolitan Area Planning Council
+706 Dudley Street,planning,2023,26,2747,42.31845541,-71.06783025,Boston,Metropolitan Area Planning Council
+Union Square: D2.2 - D2.3,planning,2023,450,50000,42.37827027,-71.0944193,Somerville,Metropolitan Area Planning Council
+Neighborhood House Charter School Expansion,planning,2023,0,21000,42.29315713,-71.0535783,Boston,Metropolitan Area Planning Council
+47-55 LaGrange St,planning,2023,176,1500,42.35171575,-71.06372048,Boston,Metropolitan Area Planning Council
+314R - 316R South ,planning,2023,2,0,42.03993304,-71.26370963,Foxborough,Metropolitan Area Planning Council
+10-12 Ward Street,planning,2023,24,0,42.37505179,-71.08905469,Somerville,Metropolitan Area Planning Council
+118-120 Broadway,planning,2023,22,3000,42.38762426,-71.08413043,Somerville,Metropolitan Area Planning Council
+10 Prospect St: D2.1 ,planning,2023,0,178890,42.37881879,-71.09402594,Somerville,Metropolitan Area Planning Council
+2147 Washington (Haley House),planning,2023,74,23215,42.33175235,-71.08233567,Boston,Metropolitan Area Planning Council
+2085 Washington St,planning,2023,64,7045,42.33267002,-71.08142144,Boston,Metropolitan Area Planning Council
+Northampton Stret Residences,planning,2023,47,0,42.34058948,-71.08277425,Boston,Metropolitan Area Planning Council
+187 Sumner Street (Grace Apartments),planning,2023,42,0,42.36938514,-71.04018671,Boston,Metropolitan Area Planning Council
+1522 Columbus Ave,planning,2023,0,75000,42.32263015,-71.09801538,Boston,Metropolitan Area Planning Council
+25 Fountain St,planning,2023,51,0,42.32450126,-71.08533136,Boston,Metropolitan Area Planning Council
+840 Columbus Ave (Northeastern Dorm),planning,2023,975,0,42.33584043,-71.08768461,Boston,Metropolitan Area Planning Council
+87-101 Cambridgepark Drive,planning,2023,0,141834,42.39496412,-71.14499344,Cambridge,Metropolitan Area Planning Council
+Independant Hotel,planning,2023,0,23030,42.36628458,-71.09214308,Cambridge,Metropolitan Area Planning Council
+544 Massachusetts Avenue,planning,2023,29,5000,42.36432459,-71.102353,Cambridge,Metropolitan Area Planning Council
+75-109 Smith Place,planning,2023,0,143153,42.39271822,-71.15093588,Cambridge,Metropolitan Area Planning Council
+Kenmore Hotel,planning,2023,0,243000,42.34873947,-71.09829042,Boston,Metropolitan Area Planning Council
+60-80 Kilmarnock Street,planning,2023,443,3200,42.34292314,-71.09907464,Boston,Metropolitan Area Planning Council
+72 Stow Road,projected,2023,25,0,42.48010261,-71.51259168,Boxborough,Metropolitan Area Planning Council
+South Station Air Rights - Phase 1,in_construction,2024,175,711000,42.35160514,-71.05512626,Boston,Metropolitan Area Planning Council
+Medfield State Hospital Clean Up and Redevelopment,planning,2024,440,0,42.21082515,-71.33396666,Medfield,Metropolitan Area Planning Council
+401 Park (Phase I & II),planning,2024,0,815660,42.34454351,-71.10275567,Boston,Metropolitan Area Planning Council
+Suffolk Downs Redevelopment (Phase 1),planning,2024,1870,845000,42.39181078,-70.99841349,Boston,Metropolitan Area Planning Council
+75 Morrissey Boulevard (Phase I),planning,2024,608,0,42.31693911,-71.05003125,Boston,Metropolitan Area Planning Council
+McCormack Public Housing Redevelopment,planning,2024,2000,0,42.32645645,-71.05593047,Boston,Metropolitan Area Planning Council
+120 West 4th Street,planning,2024,9,0,42.3410645,-71.05592886,Boston,Metropolitan Area Planning Council
+819 Beacon Street (Boston Childrens Hospital),planning,2024,500,245840,42.34760621,-71.10240734,Boston,Metropolitan Area Planning Council
+585 Kendall St (CRP) / Constellation Theater,planning,2024,0,100000,42.36404542,-71.08235986,Cambridge,Metropolitan Area Planning Council
+Holiday Inn Redevelopment,planning,2024,155,100000,42.34401582,-71.11600975,Brookline,Metropolitan Area Planning Council
+Union Square Revitalization: D3,planning,2024,375,535000,42.3761006,-71.09453951,Somerville,Metropolitan Area Planning Council
+1500 Soldiers Field Road,planning,2024,106,0,42.36005022,-71.14852845,Boston,Metropolitan Area Planning Council
+323-345 Dorchester Ave,planning,2024,265,47000,42.33688805,-71.05780356,Boston,Metropolitan Area Planning Council
+135 Bremen Street,planning,2024,94,8300,42.37200308,-71.03473503,Boston,Metropolitan Area Planning Council
+10 Stack Street,planning,2024,0,350300,42.38076114,-71.07216306,Boston,Metropolitan Area Planning Council
+Glen Brook Way,planning,2024,92,0,42.138657,-71.45165142,Medway,Metropolitan Area Planning Council
+135 Broadway/North Building,planning,2024,70,1300,42.36572961,-71.08731,Cambridge,Metropolitan Area Planning Council
+135 Broadway/South Building,planning,2024,355,0,42.36458718,-71.08816242,Cambridge,Metropolitan Area Planning Council
+84 Wadsworth Street/MIT Kendall Square Building 2,planning,2024,0,318000,42.36187245,-71.08383484,Cambridge,Metropolitan Area Planning Council
+99 A Street,planning,2024,0,210000,42.34230416,-71.0536687,Boston,Metropolitan Area Planning Council
+Herb Chambers Honda of Boston,planning,2024,0,112600,42.29747755,-71.04831947,Boston,Metropolitan Area Planning Council
+125 Lowell Street,planning,2024,20,0,42.38845843,-71.10864025,Somerville,Metropolitan Area Planning Council
+Rio Grande Project,planning,2024,241,38000,42.33008109,-71.08525967,Boston,Metropolitan Area Planning Council
+135 Dudley Street,planning,2024,155,15512,42.3283705,-71.08443985,Boston,Metropolitan Area Planning Council
+2-10 Maverick Square,planning,2024,25,10710,42.3692219,-71.03993293,Boston,Metropolitan Area Planning Council
+28-30 Geneva Street,planning,2024,27,0,42.36896,-71.03316871,Boston,Metropolitan Area Planning Council
+89 Brighton Avenue,in_construction,2025,129,7500,42.35297024,-71.1296104,Boston,Metropolitan Area Planning Council
+Lawson Farm,in_construction,2025,28,0,42.07399052,-71.28327189,Foxborough,Metropolitan Area Planning Council
+Off Wheeler Road,planning,2025,0,119523,42.47483798,-71.21373312,Burlington,Metropolitan Area Planning Council
+Stillwater Estates,planning,2025,40,,42.15405549,-71.0959334,Canton,Metropolitan Area Planning Council
+Wentworth: Student/Rec Center,planning,2025,0,46000,42.33632932,-71.09535675,Boston,Metropolitan Area Planning Council
+757 - 771 Morton Street,planning,2025,50,,42.28350617,-71.08952654,Boston,Metropolitan Area Planning Council
+125 Lincoln Street,planning,2025,0,625000,42.35134578,-71.05868295,Boston,Metropolitan Area Planning Council
+449 Cambridge Street,planning,2025,166,2400,42.35471781,-71.13572368,Boston,Metropolitan Area Planning Council
+Allston Square - Phase I,planning,2025,344,15860,42.355544,-71.132191,Boston,Metropolitan Area Planning Council
+Stone Ridge Business Park,planning,2025,0,625000,42.17073663,-71.51186829,Milford,Metropolitan Area Planning Council
+Herb Chambers Jaguar Range Rover Dealership,planning,2025,0,192321,42.34986976,-71.12900872,Boston,Metropolitan Area Planning Council
+Mattapan Heights V,planning,2025,120,0,42.27439293,-71.08720752,Boston,Metropolitan Area Planning Council
+39 Stanhope Street,planning,2025,0,124400,42.34844453,-71.07341824,Boston,Metropolitan Area Planning Council
+202 Southampton St,planning,2025,0,22400,42.33186144,-71.06598695,Boston,Metropolitan Area Planning Council
+Wentworth: Residence Hall,planning,2025,158,46000,42.3373476,-71.09716081,Boston,Metropolitan Area Planning Council
+Doran Road/Dudley Pond,planning,2025,8,,42.33264935,-71.36538034,Wayland,Metropolitan Area Planning Council
+217 Market Street (Market Street Crossing),planning,2025,116,26525,42.35678348,-71.14927627,Boston,Metropolitan Area Planning Council
+Lowe's Brighton,planning,2025,0,146000,42.35739779,-71.14467507,Boston,Metropolitan Area Planning Council
+Union Square Revitalization: D-4.3 & 4.4,planning,2025,65,0,42.37791119,-71.09524514,Somerville,Metropolitan Area Planning Council
+Concord Baptist Church,planning,2025,0,70000,42.27895,-71.08612111,Boston,Metropolitan Area Planning Council
+872 Morton Street (Morton Station Village),planning,2025,40,0,42.28122616,-71.08493355,Boston,Metropolitan Area Planning Council
+Pond Street Priority Development Site (43D),planning,2025,0,300000,42.09386377,-71.42829569,Franklin,Metropolitan Area Planning Council
+Lumber St. - West Main St. Development,planning,2025,0,175000,42.2167649,-71.53968424,Hopkinton,Metropolitan Area Planning Council
+Fire Station Redevelopment,planning,2025,19,3000,42.06497088,-71.25160332,Foxborough,Metropolitan Area Planning Council
+Whisper Way/Whisper Ridge,planning,2025,24,0,42.22875641,-71.55446399,Hopkinton,Metropolitan Area Planning Council
+Elmwood Farms III,planning,2025,15,0,42.21390867,-71.50833296,Hopkinton,Metropolitan Area Planning Council
+One Charlestown,planning,2025,2100,0,42.3795691,-71.0564193,Boston,Metropolitan Area Planning Council
+Union Point -- Remainder of Phase 1,planning,2025,1400,2047000,42.15457989,-70.9431225,Weymouth,Metropolitan Area Planning Council
+5-29 New England Ave,planning,2025,23,0,42.29102486,-71.07795777,Boston,Metropolitan Area Planning Council
+40 Thorndike Street,planning,2025,48,440000,42.36927025,-71.079487,Cambridge,Metropolitan Area Planning Council
+124 Highland Ave,planning,2025,19,0,42.38732063,-71.10103429,Somerville,Metropolitan Area Planning Council
+Motor Mart Garage ,planning,2025,231,46000,42.35103521,-71.06816891,Boston,Metropolitan Area Planning Council
+Wentworth Institute of Tech - Annex Addition,planning,2025,0,40000,42.33576253,-71.09371792,Boston,Metropolitan Area Planning Council
+1717-1725 Hyde Park Avenue,planning,2025,285,3617,42.24043265,-71.13195993,Boston,Metropolitan Area Planning Council
+78 Willow Court,planning,2025,239,0,42.32441849,-71.06401003,Boston,Metropolitan Area Planning Council
+Four Corners Station Area #4,projected,2025,100,,42.29921864,-71.0817706,Boston,Metropolitan Area Planning Council
+Readville Station Area #2,projected,2025,100,100000,42.28650865,-71.07878061,Boston,Metropolitan Area Planning Council
+West Newton Armory RFP,projected,2025,25,0,42.3497213,-71.22023184,Newton,Metropolitan Area Planning Council
+Four Corners Station Area #1,projected,2025,100,,42.30641671,-71.07840298,Boston,Metropolitan Area Planning Council
+Talbot Avenue Station Area #3,projected,2025,100,50000,42.29004286,-71.07292948,Boston,Metropolitan Area Planning Council
+Four Corners Station Area #2,projected,2025,100,,42.30462471,-71.08268065,Boston,Metropolitan Area Planning Council
+Cummis Hwy Station Area #2,projected,2025,50,,42.26983847,-71.09322743,Boston,Metropolitan Area Planning Council
+River St Station Area #2,projected,2025,100,,42.26127216,-71.11153336,Boston,Metropolitan Area Planning Council
+Morton St Station Area #4,projected,2025,100,,42.28085602,-71.08598745,Boston,Metropolitan Area Planning Council
+Cummis Hwy Station Area #4,projected,2025,50,,42.26340198,-71.1022174,Boston,Metropolitan Area Planning Council
+Cummis Hwy Station Area #1,projected,2025,50,0,42.27404448,-71.09450027,Boston,Metropolitan Area Planning Council
+Talbot Avenue Station Area #2,projected,2025,100,50000,42.29290969,-71.0746164,Boston,Metropolitan Area Planning Council
+Four Corners Station Area #3,projected,2025,100,0,42.30659965,-71.07812217,Boston,Metropolitan Area Planning Council
+Morton St Station Area #3,projected,2025,100,,42.28046571,-71.0851516,Boston,Metropolitan Area Planning Council
+Columbia Road Station Area #2,projected,2025,150,10000,42.3090064,-71.07217692,Boston,Metropolitan Area Planning Council
+Talbot Avenue Station Area #1,projected,2025,100,50000,42.29363976,-71.08289461,Boston,Metropolitan Area Planning Council
+Morton St Station Area #1,projected,2025,100,,42.28271492,-71.08554115,Boston,Metropolitan Area Planning Council
+Morton St Station Area #2,projected,2025,100,,42.28060447,-71.08242498,Boston,Metropolitan Area Planning Council
+Readville Station Area #1,projected,2025,100,100000,42.23782104,-71.13205207,Boston,Metropolitan Area Planning Council
+Cummis Hwy Station Area #3,projected,2025,50,,42.2716041,-71.10477391,Boston,Metropolitan Area Planning Council
+River St Station Area #1,projected,2025,100,,42.26692968,-71.10620389,Boston,Metropolitan Area Planning Council
+Columbia Road Station Area #1,projected,2025,150,10000,42.30940915,-71.07389848,Boston,Metropolitan Area Planning Council
+"10-26 Somerset Avenue, Winthrop, MA",projected,2025,30,1016,42.37467133,-70.98737687,Winthrop,Metropolitan Area Planning Council
+1 Court Street Residence Hall,projected,2025,0,2200,42.3591051,-71.05786156,Boston,Metropolitan Area Planning Council
+111 South Street (Boynton Yards Phase 2) ,projected,2025,425,196000,42.37528259,-71.09189222,Somerville,Metropolitan Area Planning Council

--- a/app/javascript/pages/components/gallery/2020/March.jsx
+++ b/app/javascript/pages/components/gallery/2020/March.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable max-len */
 import * as d3 from 'd3';
 import React, { useEffect, useState } from 'react';
-import axios from 'axios';
 import D3Map from '../D3Map';
 
 let iterator;
@@ -12,15 +11,15 @@ const colors = {
 };
 
 const tooltipHtml = (development) => {
-  let tooltipDetails = `<p class='tooltip__title'>${development.attributes.name}</p>
+  let tooltipDetails = `<p class='tooltip__title'>${development.name}</p>
   <ul class='tooltip__list'>
-  <li class='tooltip__text'>Est. completion in ${development.attributes.year_compl}</li>
-  <li class='tooltip__text'>${development.attributes.municipal}</li>`;
-  if (development.attributes.hu) {
-    tooltipDetails += `<li class='tooltip__text'>${d3.format(',')(development.attributes.hu)} housing units</li>`;
+  <li class='tooltip__text'>Est. completion in ${development.year_compl}</li>
+  <li class='tooltip__text'>${development.municipal}</li>`;
+  if (development.hu) {
+    tooltipDetails += `<li class='tooltip__text'>${d3.format(',')(development.hu)} housing units</li>`;
   }
-  if (development.attributes.commsf) {
-    tooltipDetails += `<li class='tooltip__text'>${d3.format(',')(development.attributes.commsf)} square feet of commercial space</li>`;
+  if (development.commsf) {
+    tooltipDetails += `<li class='tooltip__text'>${d3.format(',')(development.commsf)} square feet of commercial space</li>`;
   }
   tooltipDetails += '</ul>';
   return tooltipDetails;
@@ -200,17 +199,17 @@ const drawMap = (newDevelopments, selection) => {
   };
 
   const dataByYear = [
-    newDevelopments.filter((d) => d.attributes.year_compl === 2015),
-    newDevelopments.filter((d) => d.attributes.year_compl === 2016),
-    newDevelopments.filter((d) => d.attributes.year_compl === 2017),
-    newDevelopments.filter((d) => d.attributes.year_compl === 2018),
-    newDevelopments.filter((d) => d.attributes.year_compl === 2019),
-    newDevelopments.filter((d) => d.attributes.year_compl === 2020),
-    newDevelopments.filter((d) => d.attributes.year_compl === 2021),
-    newDevelopments.filter((d) => d.attributes.year_compl === 2022),
-    newDevelopments.filter((d) => d.attributes.year_compl === 2023),
-    newDevelopments.filter((d) => d.attributes.year_compl === 2024),
-    newDevelopments.filter((d) => d.attributes.year_compl === 2025),
+    newDevelopments.filter((d) => d.year_compl === '2015'),
+    newDevelopments.filter((d) => d.year_compl === '2016'),
+    newDevelopments.filter((d) => d.year_compl === '2017'),
+    newDevelopments.filter((d) => d.year_compl === '2018'),
+    newDevelopments.filter((d) => d.year_compl === '2019'),
+    newDevelopments.filter((d) => d.year_compl === '2020'),
+    newDevelopments.filter((d) => d.year_compl === '2021'),
+    newDevelopments.filter((d) => d.year_compl === '2022'),
+    newDevelopments.filter((d) => d.year_compl === '2023'),
+    newDevelopments.filter((d) => d.year_compl === '2024'),
+    newDevelopments.filter((d) => d.year_compl === '2025'),
   ];
   let position = 0;
   let year = 2015;
@@ -247,9 +246,9 @@ const drawMap = (newDevelopments, selection) => {
       .duration(5000)
       .attr('r', (development) => {
         if (selection === 'housing') {
-          return housingRadius(development.attributes.hu);
+          return housingRadius(development.hu);
         }
-        return commercialRadius(development.attributes.commsf);
+        return commercialRadius(development.commsf);
       });
 
     newPoint.attr('fill', colors.new)
@@ -269,8 +268,8 @@ const drawMap = (newDevelopments, selection) => {
 
   document.querySelectorAll('.d3-map__option-label').forEach((option) => option.addEventListener('click', clearInterval(iterator)));
   updateVisualization();
-  d3.select('.d3-map__points').raise();
   iterator = setInterval(updateVisualization, 5000);
+  d3.select('.d3-map__points').raise();
 };
 
 const March = () => {
@@ -278,13 +277,10 @@ const March = () => {
   const [housingData, setHousingData] = useState([]);
   const [commercialData, setCommercialData] = useState([]);
   useEffect(() => {
-    const newMassBuilds = 'https://api.massbuilds.com/developments?filter%5Byear_compl%5D%5Bcol%5D=year_compl&filter%5Byear_compl%5D%5Bname%5D=Year%20complete&filter%5Byear_compl%5D%5BglossaryKey%5D=YEAR_COMPLETE&filter%5Byear_compl%5D%5Btype%5D=number&filter%5Byear_compl%5D%5Bfilter%5D=metric&filter%5Byear_compl%5D%5Bvalue%5D=2014&filter%5Byear_compl%5D%5Binflector%5D=%3E';
-    axios.get(newMassBuilds, { headers: { Accept: 'application/vnd.api+json' } }).then((mapData) => {
-      const newDevelopments = mapData.data.data.filter((development) => development.attributes.rpa_name === 'Metropolitan Area Planning Council'
-        && development.attributes.year_compl <= 2025)
-        .map((development) => ({ attributes: development.attributes, coordinates: [development.attributes.longitude, development.attributes.latitude] }));
-      const housing = newDevelopments.filter((development) => development.attributes.hu > 0);
-      const commercial = newDevelopments.filter((development) => development.attributes.commsf > 0);
+    d3.csv('/assets/march2020.csv').then((mapData) => {
+      const newDevelopments = mapData.map((development) => ({ ...development, coordinates: [development.longitude, development.latitude] }));
+      const housing = newDevelopments.filter((development) => development.hu > 0);
+      const commercial = newDevelopments.filter((development) => development.commsf > 0);
       setHousingData(housing);
       setCommercialData(commercial);
       drawLegend(currentlySelected);
@@ -355,7 +351,8 @@ Data like this helps shape our region and is available because MassBuilds collec
         {' '}
 today.
       </p>
-      <p><em>All statistics up-to-date as of 9:30am, 2/28/2020, only projects in the MAPC region analyzed.</em></p>
+      <p><em>Map data up-to-date as of 11:15am, 4/17/2020.
+      <br />All statistics up-to-date as of 9:30am, 2/28/2020, only projects in the MAPC region analyzed.</em></p>
     </>
   );
 };


### PR DESCRIPTION
# Why is this change necessary?
After a month or so, we wanted to remove the dynamic API call to MassBuilds and instead refer to a static CSV file (pulled today at 11:15AM)

# How does it address the issue?
- Remove API call and edit d3 code to accommodate new data source
- Double-checked data numbers to ensure we were pulling the correct specifications of developments (MAPC region with a `year_compl` value between 2015 - 2025)

# What side effects does it have?
I noticed two things when getting to work on this; because they occurred before I swapped data sources, I'm making two new issues.
1) Tooltip moves slightly, but mostly stays in the top left corner of the map (probably a CSS issue)
2) Sometimes, the CSV data is ready to go before the base map is. In these cases, the first year of data loads underneath the MAPC region. I tried resolving this with a timeout but it doesn't seem to be a static amount of time, so a more dynamic solution will be required.
