### PR TITLE
Add necessary d3-array functions directly into January class

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "babel-jest": "^24.9.0",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "d3": "^5.14.2",
-    "d3-array": "^2.4.0",
     "es6-promise": "^4.2.4",
     "eslint": "^6.7.2",
     "eslint-config-airbnb": "^18.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3003,11 +3003,6 @@ d3-array@1, d3-array@^1.1.1, d3-array@^1.2.0:
   resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.4.tgz#635ce4d5eea759f6f605863dbcfc30edc737f71f"
   integrity sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==
 
-d3-array@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.4.0.tgz#87f8b9ad11088769c82b5ea846bcb1cc9393f242"
-  integrity sha512-KQ41bAF2BMakf/HdKT865ALd4cgND6VcIztVQZUTt0+BH3RWy6ZYnHghVXf6NFjt2ritLr8H1T8LreAAlfiNcw==
-
 d3-axis@1:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/d3-axis/-/d3-axis-1.0.12.tgz#cdf20ba210cfbb43795af33756886fb3638daac9"


### PR DESCRIPTION
# Why is this change necessary?
A few `for...of` loops in the [d3-array](https://github.com/d3/d3-array) package weren't getting transpiled with Babel, resulting in the entire DataCommon site to not display in IE11.

# How does it address the issue?
As I note in the commit history, this ideally would have been resolved with edits to the Babel and Webpack config (perhaps some Regex excluding all node modules but d3-array?). However, they just never connected. After several days of attempts, I resolved this by implementing the necessary d3 functions directly in the January class file (the polyfill works fine for non-node-module code).

# What side effects does it have?
I removed the d3-array package from the package.json to keep things as clean as possible.