### PR TITLE
Att/307 particle header

### DIFF
--- a/app/javascript/pages/components/partials/Particles.jsx
+++ b/app/javascript/pages/components/partials/Particles.jsx
@@ -8,7 +8,7 @@ class Particles extends React.Component {
     this.canvasRef = React.createRef();
     this.state = {
       width: window.innerWidth,
-      height: 421,
+      height: 423,
       dotArray: [],
       randNum(measurement) {
         return Math.floor(Math.random() * Math.floor(measurement));
@@ -37,7 +37,9 @@ class Particles extends React.Component {
 
   componentDidMount() {
     window.addEventListener('resize', this.updateDimensions);
-    if (window.innerWidth <= 770) {
+    if (window.innerWidth <= 480) {
+      this.setState({ height: 205 });
+    } else if (window.innerWidth <= 770) {
       this.setState({ height: 220 });
     }
     const contxt = this.canvas.getContext('2d');
@@ -161,10 +163,13 @@ class Particles extends React.Component {
   }
 
   updateDimensions() {
-    this.setState({
-      width: window.innerWidth,
-      height: window.innerWidth <= 770 ? 221 : 421,
-    });
+    if (window.innerWidth <= 480) {
+      this.setState({ width: window.innerWidth, height: 205 });
+    } else if (window.innerWidth <= 770) {
+      this.setState({ width: window.innerWidth, height: 220 });
+    } else {
+      this.setState({ width: window.innerWidth, height: 423 });
+    }
   }
 
   render() {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,8 @@
     <%= javascript_pack_tag 'application' %>
     <%= javascript_pack_tag 'direct_uploads' %>
     <%= yield :head %>
+
+    <%= favicon_link_tag asset_path('favicon.ico') %>
   </head>
 
   <body>


### PR DESCRIPTION
Resolves #307 (and #322 because of how tiny a change that is).

# Why is this change necessary?
On Firefox desktop and all mobile views, the Particle header on the homepage was ~2 pixels off. No one to my knowledge has ever pointed this out as a major issue, but _I knew_.

# How does it address the issue?
I added an additional width/height breakpont (480px wide) to handle the transition from tablet to mobile, and made the whole component 2 pixels taller. Is there a more elegant solution based around deductive algebra? Probably. Does it make sense to find that solution right now? Probably not.

# What side effects does it have?
I included adding the favicon in its own commit, but not its own PR, since it's just one line of code.
