### PR TITLE
Setup Sentry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem 'aws-sdk-s3', require: false
 gem 'mini_magick'
 gem 'non-digest-assets'
 gem 'petfinder'
+gem 'sentry-raven'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -309,6 +309,8 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
+    sentry-raven (3.1.1)
+      faraday (>= 1.0)
     shellany (0.0.1)
     spring (2.1.1)
     spring-commands-rspec (1.0.4)
@@ -389,6 +391,7 @@ DEPENDENCIES
   rubyzip
   sass-rails (>= 6)
   selenium-webdriver
+  sentry-raven
   spring-commands-rspec
   terminal-notifier-guard
   tzinfo-data

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,9 @@
 class ApplicationController < ActionController::Base
+  before_action :set_raven_context
+  
+  private
+  
+  def set_raven_context
+    Raven.extra_context(params: params.to_unsafe_h, url: request.url)
+  end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -45,3 +45,7 @@ module Datacommon
     end
   end
 end
+
+Raven.configure do |config|
+  config.dsn = 'https://4bb1a18f7fcf41a183a9033e4763ab7c@o109972.ingest.sentry.io/5453345'
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -48,4 +48,5 @@ end
 
 Raven.configure do |config|
   config.dsn = 'https://4bb1a18f7fcf41a183a9033e4763ab7c@o109972.ingest.sentry.io/5453345'
+  config.environments = %w[staging production]
 end


### PR DESCRIPTION
* Setup Sentry with relevant configuration and settings to catch and transmit exceptions.

Resolves #41  .

# Why is this change necessary?
We want to track errors and exceptions in Sentry.

# How does it address the issue?
It adds the gem and relevant configuration.

# What side effects does it have?
