### PR TITLE
Att/246 link highlight

### DIFF
--- a/__mocks__/file-mock.js
+++ b/__mocks__/file-mock.js
@@ -1,0 +1,1 @@
+module.exports = 'test-file-stub';

--- a/app/javascript/pages/components/partials/Header.jsx
+++ b/app/javascript/pages/components/partials/Header.jsx
@@ -1,35 +1,35 @@
 import React from 'react';
-
 import logoImg from '../../assets/images/logo.svg';
 
-
-class Header extends React.Component {
-
-  render() {
-    const highlightCPLink = this.props.location.pathname.startsWith('/profile');
-
-    return (
-      <header className="container">
-        <nav>
-          <div className="scroll-wrapper">
-            <div className="header-brand">
-              <a href="/">
-                <img src={logoImg} alt="DataCommon Logo" />
-                DataCommon
-              </a>
-            </div>
-
-            <ul>
-              <li><a href="/browser">Datasets</a></li>
-              <li><a className={highlightCPLink ? 'active' : null} href="/#community-profiles">Community Profiles</a></li>
-              <li><a href="/gallery">Gallery</a></li>
-            </ul>
-          </div>
-        </nav>
-      </header>
-    );
+function handleActivePage(subdirectory, link = '/home') {
+  if (subdirectory.startsWith(link)) {
+    return 'active';
+  } if (subdirectory.startsWith('/calendar') && link === '/gallery') {
+    return 'active';
   }
+  return null;
+}
 
-};
+const Header = ({ location }) => (
+  <header className="container">
+    <nav>
+      <div className="scroll-wrapper">
+        <div className="header-brand">
+          <a href="/">
+            <img src={logoImg} alt="DataCommon Logo" />
+            DataCommon
+          </a>
+        </div>
+
+        <ul>
+          <li><a className={handleActivePage(location.pathname, '/browser')} href="/browser">Datasets</a></li>
+          <li><a className={handleActivePage(location.pathname, '/profile')} href="/#community-profiles">Community Profiles</a></li>
+          <li><a className={handleActivePage(location.pathname, '/gallery')} href="/gallery">Gallery</a></li>
+        </ul>
+      </div>
+    </nav>
+  </header>
+);
 
 export default Header;
+export { handleActivePage };

--- a/app/javascript/pages/components/partials/__tests__/Header.test.js
+++ b/app/javascript/pages/components/partials/__tests__/Header.test.js
@@ -1,0 +1,20 @@
+/* eslint-disable no-undef */
+import { handleActivePage } from '../Header';
+
+describe('Header navigation', () => {
+  test('displays no active links on the homepage', () => {
+    expect(handleActivePage('/')).toBeNull();
+  });
+
+  test('displays the correct link as active if it matches the beginning of the path location', () => {
+    expect(handleActivePage('/browser/datasets/170', '/browser')).toBe('active');
+  });
+
+  test('displays Gallery as active if on a calendar visualization', () => {
+    expect(handleActivePage('/calendar/2020/january', '/gallery')).toBe('active');
+  });
+
+  test('displays inactive link for other non-matching path locations and links', () => {
+    expect(handleActivePage('/browser', '/profile')).toBeNull();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,20 @@
 {
   "name": "datacommon",
   "private": true,
+  "scripts": {
+    "test": "jest"
+  },
+  "jest": {
+    "moduleNameMapper": {
+      ".+\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/file-mock.js"
+    },
+    "testPathIgnorePatterns": [
+      "node_modules",
+      "\\.cache",
+      "<rootDir>.*/public",
+      "config/webpack"
+    ]
+  },
   "dependencies": {
     "@babel/preset-react": "^7.7.0",
     "@babel/runtime": "^7.6.3",


### PR DESCRIPTION
Resolves #246 .

# Why is this change necessary?
We only utilized the "Active" link styling when visiting a Community Profile page; not when visiting the data browser, a dataset, the gallery, or a calendar visualization. "Datasets" and "Gallery" each have multiple sub-pages, but it was not visually clear.

# How does it address the issue?
Re-write the Header component as a pure function that checks whether or not the beginning of the current page location matches a given string "key." This is used to determine whether or not to display the `active` styling.

# What side effects does it have?
Since I just did a bunch of similar tests in Zoning Atlas, I took the opportunity to breathe a little more life into our Jest setup. I think that `webpack/config/test.js` is a set-up file for the testing environment (as opposed to an actual test file) so I set Jest to ignore that as well as the usual `node_modules`, `cache`, and so on.
