### PR TITLE
Set Ruby route for municipal profiles

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,4 +12,5 @@ Rails.application.routes.draw do
   get '/browser', to: 'pages#index'
   get '/browser/datasets/*dataset', to: 'pages#index'
   get '/browser/*menuOneSelectedItem', to: 'pages#index'
+  get '/profile/*muni/*tab', to: 'pages#index'
 end


### PR DESCRIPTION
Resolves #274  .

# Why is this change necessary?
External links to particular community profiles (and tabs) left the user with a generic Ruby error message. The only way to access these pages was to search for a community on the homepage and then click the appropriate tab.

# How does it address the issue?
Since most routing is still handled by Ruby, we just needed to set a controller for this particular page. Like most other React pages, it uses the `pages#index` controller.

# What side effects does it have?
None
