### PR TITLE
Resolve #250 Geospatial Metadata Download

### DIFF
--- a/app/javascript/pages/components/partials/DatasetHeader.jsx
+++ b/app/javascript/pages/components/partials/DatasetHeader.jsx
@@ -16,7 +16,7 @@ function downloadMetadata(
   let rows;
   if (database === 'towndata' || database === 'gisdata') {
     const metadataName = metadata.documentation.metadata.eainfo.detailed.attr.map(
-      (attr) => (attr.attlabl ? attr.attlabel : 'undefined')
+      (attr) => (attr.attrlabl ? attr.attrlabl : 'undefined')
     );
     const metadataAlias = metadata.documentation.metadata.eainfo.detailed.attr.map(
       (attr) => attr.attalias


### PR DESCRIPTION
* Fix typo of key name to populate column labels (or should I say labls) in metadata download.
