### PR TITLE
Resolve #357 Dataset Link History

### DIFF
--- a/app/javascript/pages/components/App.jsx
+++ b/app/javascript/pages/components/App.jsx
@@ -24,17 +24,28 @@ const App = (props) => (
         <Route exact path="/faq" component={Faq} />
         <Route
           path="/profile/:muni/:tab?"
-          render={(props2) => (props.muniOptions.includes(props2.match.params.muni)
-            ? (props.tabOptions.includes(props2.match.params.tab)
-              ? (<CommunityProfiles {...props2} />)
-              : (<Redirect to={`/profile/${props2.match.params.muni}/${props.tabOptions[0]}`} />))
-            : (<Redirect to="/" />))}
+          render={(props2) =>
+            props.muniOptions.includes(props2.match.params.muni) ? (
+              props.tabOptions.includes(props2.match.params.tab) ? (
+                <CommunityProfiles {...props2} />
+              ) : (
+                <Redirect
+                  to={`/profile/${props2.match.params.muni}/${props.tabOptions[0]}`}
+                />
+              )
+            ) : (
+              <Redirect to="/" />
+            )
+          }
         />
         <Route exact path="/gallery" component={Gallery} />
         <Route exact path="/login" component={Login} />
         <Route path="/calendar/:year/:month" component={CalendarEntry} />
         <Route path="/browser/datasets/:id" component={DataViewer} />
-        <Route path="/browser/:menuOneSelectedItem" component={Browser} />
+        <Route
+          path="/browser/:menuOneSelectedItem?/:menuTwoSelectedItem?"
+          component={Browser}
+        />
         <Route path="/browser" component={Browser} />
         <PrivateRoute exact path="/admin" component={Admin} />
       </Switch>

--- a/app/javascript/pages/components/Browser.jsx
+++ b/app/javascript/pages/components/Browser.jsx
@@ -46,6 +46,10 @@ class Browser extends React.Component {
   }
 
   handleMenuSelectedItem(childKey, event) {
+    if (childKey === 'menuOneSelectedItem') {
+      delete this.state.menuTwoSelectedItem;
+    }
+
     this.setState(
       {
         [childKey]: event.currentTarget.getAttribute('data-key'),

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,6 @@ Rails.application.routes.draw do
   get '/calendar/*date', to: 'pages#index'
   get '/browser', to: 'pages#index'
   get '/browser/datasets/*dataset', to: 'pages#index'
-  get '/browser/*menuOneSelectedItem', to: 'pages#index'
+  get '/browser/*selectedItems', to: 'pages#index'
   get '/profile/*muni/*tab', to: 'pages#index'
 end


### PR DESCRIPTION
* Update routes to allow for one or two params in the URL to display datasets.
* Update state code to push clicks of menu items into the router history so that they will display in the URL.
* Update the function calls inside onMenuClick inside arrow functions so that they are only called when clicked, not when the page is loaded.
* Remove dead code: history import.
* Update constructor to set menuTwoSelectedItem from the URL params so that direct links will display a page with the correct datasets displayed.
* Remove outdated comment: some of the code in DataViewer component is still coupled to this method of changing what page is displayed so we cannot currently use history.push.
