### PR TITLE
Add map resize calls to April 2020, December 2020, January 2021

### DIFF
--- a/app/javascript/pages/components/gallery/2020/April.jsx
+++ b/app/javascript/pages/components/gallery/2020/April.jsx
@@ -47,6 +47,7 @@ const April = () => {
       return colors[3];
     };
     aprilMap.on('load', () => {
+      aprilMap.resize();
       aprilMap.setPaintProperty('background', 'background-color', '#FBF9EE');
       aprilMap.setPaintProperty('Non MAPC municipalities', 'fill-color', '#FBF9EE');
       aprilMap.setPaintProperty('External State', 'fill-color', '#FBF9EE');
@@ -156,7 +157,8 @@ const April = () => {
             <text x="8" y="246" className="map__legend-entry" fill="#1F4E46">
               &#8226;
               {' '}
-              <a href="https://data.census.gov/cedsci/map?q=massachusetts&g=0400000US25.140000,25&hidePreview=false&tid=ACSST5Y2018.S2801&vintage=2018&cid=S2801_C01_001E&t=Telephone,%20Computer,%20and%20Internet%20Access" className="calendar-viz__link" fill="#1F4E46">2014⁠–2018 ACS
+              <a href="https://data.census.gov/cedsci/map?q=massachusetts&g=0400000US25.140000,25&hidePreview=false&tid=ACSST5Y2018.S2801&vintage=2018&cid=S2801_C01_001E&t=Telephone,%20Computer,%20and%20Internet%20Access" className="calendar-viz__link" fill="#1F4E46">
+                2014⁠–2018 ACS
               </a>
             </text>
           </svg>
@@ -164,11 +166,12 @@ const April = () => {
       </div>
       <p>The COVID-19 pandemic has upended daily life in Greater Boston and around the world. Thousands of people can’t report to work, and millions are being told to cease nonessential travel. Never before has the internet been so essential for working remotely and staying connected. Unfortunately, 10 percent of the region’s households still lack the technology needed to access the internet from home. Not only does this inequity make it harder for people to get the information and socialization they need to make it through this crisis; it will also impact the decennial US census being conducted this month.</p>
       <p>While the census might seem extraneous to some people right now, it is of utmost importance to the functioning of government, including preparation for future public emergencies. Census counts determine legislative apportionment and districts; are the basis for federal funding allocation; and inform innumerable policy, planning, emergency response, and business decisions.</p>
-      <p>Even with this year’s new option to answer the census online, getting every household to respond is a tough job. This is especially true in
-      {' '}
+      <p>
+        Even with this year’s new option to answer the census online, getting every household to respond is a tough job. This is especially true in
+        {' '}
         <a href="https://www.bostonindicators.org/reports/report-website-pages/census-2020" className="calendar-viz__link">“hard-to-count”</a>
         {' '}
-      communities where limited English proficiency, immigration status, nontraditional housing arrangements, and distrust of government, among other factors, are formidable barriers to getting a complete count. Many municipalities and community-based organizations had planned extensive personal outreach—tabling, fairs and parties, and question assistance centers—to promote census response in these neighborhoods. However, the current need for “social distancing” means that all of these in-person efforts have been cancelled.
+        communities where limited English proficiency, immigration status, nontraditional housing arrangements, and distrust of government, among other factors, are formidable barriers to getting a complete count. Many municipalities and community-based organizations had planned extensive personal outreach—tabling, fairs and parties, and question assistance centers—to promote census response in these neighborhoods. However, the current need for “social distancing” means that all of these in-person efforts have been cancelled.
       </p>
       <p>Like many jobs, census outreach and follow-up efforts can’t all be shifted online. As shown on the map, hard-to-count tracts often correspond to those lacking the technology needed to access the internet. In some neighborhoods, over 30 percent of households do not have a computer, smartphone, tablet, or some other computing device. This will make it hard to reach households with online advertising promoting census response, and these same households will have to wait for a paper form rather than responding online. The digital divide may depress return rates among the most at-risk communities, with long term effects on funding, services, and representation.</p>
       <p>It’s more critical than ever to respond promptly to the census so that follow-up efforts can be focused on communities that need it. As the current pandemic accelerates our transformation into a more digital region, we must pay attention to equity of access to the online world.</p>

--- a/app/javascript/pages/components/gallery/2020/December.jsx
+++ b/app/javascript/pages/components/gallery/2020/December.jsx
@@ -34,7 +34,11 @@ function setHeader(currentMuni, medianObj) {
           {toCamelCase(currentMuni)}
         </h3>
         <h4 className="calendar-viz__chart-subtitle">
-          Median download speed: {d3.format('.2f')(medianObj[currentMuni])} Mbps
+          Median download speed:
+          {' '}
+          {d3.format('.2f')(medianObj[currentMuni])}
+          {' '}
+          Mbps
         </h4>
       </>
     );
@@ -95,13 +99,14 @@ const December = () => {
           row.muni,
           row.median_download_speed_mbps_2020 !== '-'
             ? colorPolygon(+row.median_download_speed_mbps_2020)
-            : colorPalette[4]
+            : colorPalette[4],
         );
         tempMedianObj[row.muni] = row.median_download_speed_mbps_2020;
       });
       setMedianObj(tempMedianObj);
       colorExpression.push(colorPalette[4]);
       map.on('load', () => {
+        map.resize();
         map.addLayer({
           id: 'Median Download Speed',
           type: 'fill',
@@ -356,13 +361,15 @@ const December = () => {
         adequate device and digital literacy.
       </p>
       <p>
-        For a household already working to bridge the{' '}
+        For a household already working to bridge the
+        {' '}
         <a
           href="https://www.mapc.org/resource-library/digital-divide/"
           className="calendar-viz__link"
         >
           Digital Divide
-        </a>{' '}
+        </a>
+        {' '}
         – already likely to have slower or fewer devices and to face barriers to
         internet fluency – low download speeds and poor connectivity can make
         things even harder.
@@ -393,7 +400,8 @@ const December = () => {
       </ol>
       <p>
         For assistance in exploring issues related to the digital divide,
-        contact{' '}
+        contact
+        {' '}
         <a href="mailto:jeichen@mapc.org" className="calendar-viz__link">
           MAPC Senior Economic Development Planner, Josh Eichen
         </a>
@@ -401,7 +409,8 @@ const December = () => {
       </p>
       <p>
         <em>
-          The M-Lab NDT Data Set 2020-01-01–2020-11-23.{' '}
+          The M-Lab NDT Data Set 2020-01-01–2020-11-23.
+          {' '}
           <a href="https://www.measurementlab.net/tests/ndt/" className="calendar-viz__link">
             https://www.measurementlab.net/tests/ndt/
           </a>

--- a/app/javascript/pages/components/gallery/2021/January.jsx
+++ b/app/javascript/pages/components/gallery/2021/January.jsx
@@ -2,7 +2,7 @@
 /* eslint-disable object-curly-newline */
 import React, { useState } from 'react';
 import { Helmet } from 'react-helmet';
-import { MapContainer, TileLayer, ZoomControl, Popup } from 'react-leaflet';
+import { MapContainer, TileLayer, ZoomControl, Popup, useMapEvent } from 'react-leaflet';
 import { FeatureLayer } from 'react-esri-leaflet';
 import MapLegend from '../../visualizations/MapLegend';
 
@@ -21,6 +21,13 @@ const legend = [
   { color: '#0000E3', value: '300–399', min: 300, max: 400 },
   { color: dataNa, value: 'Data n/a' },
 ];
+
+function ResizeComponent() {
+  const map = useMapEvent('load', () => {
+    map.resize();
+  });
+  return null;
+}
 
 const January = () => {
   const [selectedZone, setZone] = useState('');
@@ -53,6 +60,7 @@ const January = () => {
           minZoom={9}
           zoomControl={false}
         >
+          <ResizeComponent />
           <TileLayer
             url="https://api.mapbox.com/styles/v1/mapbox/light-v10/tiles/{z}/{x}/{y}/?access_token=pk.eyJ1IjoibWFwYm94IiwiYSI6ImNpejY4M29iazA2Z2gycXA4N2pmbDZmangifQ.-g_vE53SD2WrJ6tFX7QHmA#1.07/0/0"
             attribution='© <a href="https://www.mapbox.com/about/maps/">Mapbox</a> © <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> <strong><a href="https://www.mapbox.com/map-feedback/" target="_blank">Improve this map</a></strong>'


### PR DESCRIPTION
Resolves #368 .

# Why is this change necessary?
For some reason, Chrome users sometimes view only partially-loaded maps, or the height maxes out at 300px instead of reaching the expected 500px.

# How does it address the issue?
After the map loads, a `resize` event is fired/ Because the rest of the DOM is set, the map should now fill its proper space. To test, go to each map page on Chrome, then hard refresh, then regular refresh; the map should load normally in all 3 scenarios.

# What side effects does it have?
Users with an initially-partially-loaded map will briefly notice the resize.