### PR TITLE
Remove calendar from landing and blank months from gallery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ yarn-debug.log*
 # dotenv suppressions
 .env.*.local
 .env.local
+.env
 
 # RSpec Suppresions
 /spec/examples.txt

--- a/app/javascript/pages/components/Home.jsx
+++ b/app/javascript/pages/components/Home.jsx
@@ -50,29 +50,12 @@ class Home extends React.Component {
               more. Always with data first, and always with an interdisciplinary
               lens.
             </p>
-            <p>
-              <strong>May’s visualization</strong>
-              {' '}
-              displays the distribution of American Rescue Plan funds across the state. We explored if determinations from the older federal formula match current community needs.
-            </p>
             <CallToAction
               link="/gallery"
               text="View Gallery"
               extraClassNames="gallery-spotlight__cta"
             />
           </div>
-          <Link to="/gallery" className="gallery-spotlight__link">
-            <img
-              src={CalendarImage}
-              className="gallery-spotlight__image"
-              alt="gallery"
-            />
-          </Link>
-          <CallToAction
-            link="/gallery"
-            text="View Gallery"
-            extraClassNames="gallery-spotlight__cta--mobile"
-          />
         </section>
 
         <div className="container tight page-section">

--- a/app/javascript/pages/components/gallery/CalendarGrid.jsx
+++ b/app/javascript/pages/components/gallery/CalendarGrid.jsx
@@ -22,10 +22,7 @@ function populateGrid(selectedYear) {
       );
     }
     return (
-      <BlankCalendarItem
-        month={`${currentMonth} ${selectedYear}`}
-        key={`b-${currentMonth}-${selectedYear}`}
-      />
+      null
     );
   });
 }


### PR DESCRIPTION
Resolves #400  .

# Why is this change necessary?

This removes the 2021 calendar image from the home page, which highlighted our backlog of calendar viz's.

# How does it address the issue?

# What side effects does it have?
